### PR TITLE
fix: Tailwind v4 CSS loading in production

### DIFF
--- a/web/app/globals.css
+++ b/web/app/globals.css
@@ -2,6 +2,10 @@
 @import "tw-animate-css";
 @import "shadcn/tailwind.css";
 
+@source "../components";
+@source "../lib";
+@source "../app";
+
 @custom-variant dark (&:is(.dark *));
 
 *, *::before, *::after { box-sizing: border-box; }

--- a/web/postcss.config.mjs
+++ b/web/postcss.config.mjs
@@ -1,0 +1,8 @@
+/** @type {import('postcss-load-config').Config} */
+const config = {
+  plugins: {
+    "@tailwindcss/postcss": {},
+  },
+};
+
+export default config;


### PR DESCRIPTION
## Summary
- Added missing `postcss.config.mjs` with `@tailwindcss/postcss` plugin — required for Tailwind v4 to process utility classes
- Added `@source` directives to `globals.css` to explicitly scan `../components`, `../lib`, and `../app` directories
- Without these, the production build contained only Tailwind theme variables (~41KB) but zero utility classes, rendering all pages unstyled

## Impact
All pages now render with full Tailwind styling. CSS went from 41KB (theme only) to 53KB (theme + utilities).

## Test plan
- [x] Clean build succeeds
- [x] 2,497 Python tests pass
- [x] Visual verification of all pages (landing, forecast, race detail, types, type detail, county detail, methodology)
- [x] Dark mode works
- [x] Mobile responsive layout verified at 375px

🤖 Generated with [Claude Code](https://claude.com/claude-code)