### PR TITLE
fix: candidate name overflow in FitScoreSection

### DIFF
--- a/web/components/forecast/FitScoreSection.tsx
+++ b/web/components/forecast/FitScoreSection.tsx
@@ -112,7 +112,7 @@ function CandidateRow({ entry, maxScore }: CandidateRowProps) {
       </span>
 
       {/* Name + metadata */}
-      <div style={{ minWidth: 0 }}>
+      <div style={{ minWidth: 0, overflow: "hidden" }}>
         <div style={{ display: "flex", alignItems: "baseline", gap: "4px", flexWrap: "wrap" }}>
           <Link
             href={`/candidates/${entry.bioguide_id}`}
@@ -121,7 +121,6 @@ function CandidateRow({ entry, maxScore }: CandidateRowProps) {
               fontWeight: 600,
               color,
               textDecoration: "none",
-              overflow: "hidden",
               textOverflow: "ellipsis",
               whiteSpace: "nowrap",
             }}


### PR DESCRIPTION
## Summary
- Move `overflow: hidden` from Link style to parent div for proper text truncation in fit score candidate rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)