### PR TITLE
feat(polls): RCP primary poll scraper with candidate-level schema

### DIFF
--- a/docs/knowledge/poll-sources.md
+++ b/docs/knowledge/poll-sources.md
@@ -1,0 +1,70 @@
+# Poll Sources — Coverage Notes
+
+Inventory of the poll scrapers that populate `data/polls/*.csv` on each
+weekly refresh (`~/scripts/wethervane-poll-scrape.sh`).
+
+## General-election polls — `polls_2026.csv`
+
+Produced by `scripts/scrape_2026_polls.py`. Triple-sourced (in priority
+order): **270toWin → RealClearPolling → Wikipedia**. The dedup layer keeps
+the highest-priority source on any `(pollster, date, race)` key.
+
+Schema: `race, geography, geo_level, dem_share, n_sample, date, pollster, notes`.
+`dem_share` is the two-party Democratic fraction (`D / (D + R)`).
+
+Covers 27 Senate + Governor 2026 races plus the generic congressional ballot.
+
+## Primary polls — `primary_polls_2026.csv`
+
+Produced by `scripts/scrape_rcp_primaries.py` (added 2026-04-21). **RCP only**
+— primaries are within-party contests, so Wikipedia/270toWin tabular scraping
+doesn't cleanly apply.
+
+Schema: `race_key, geography, geo_level, party, date, pollster, n_sample,
+candidates_json, is_primary, notes`. `candidates_json` is a JSON array of
+`{"name": str, "pct": float}` sorted by pct descending (leader first).
+
+RCP primary URL pattern: `/polls/{senate|governor}/{republican|democratic}-primary/{year}/{state}`.
+**No candidate suffix** — unlike general-election matchup pages, primary pages
+aggregate all polled candidates at the state-level URL.
+
+Tracked 2026 primaries (verified against live RCP 2026-04-21):
+
+| race_key                                  | URL                                                            |
+|-------------------------------------------|----------------------------------------------------------------|
+| 2026 GA Senate Republican Primary         | `/polls/senate/republican-primary/2026/georgia`               |
+| 2026 TX Senate Republican Primary         | `/polls/senate/republican-primary/2026/texas`                 |
+| 2026 TX Senate Democratic Primary         | `/polls/senate/democratic-primary/2026/texas`                 |
+| 2026 IL Senate Democratic Primary         | `/polls/senate/democratic-primary/2026/illinois`              |
+| 2026 GA Governor Republican Primary       | `/polls/governor/republican-primary/2026/georgia`             |
+| 2026 OK Governor Republican Primary       | `/polls/governor/republican-primary/2026/oklahoma`            |
+| 2026 SC Governor Republican Primary       | `/polls/governor/republican-primary/2026/south-carolina`      |
+| 2026 RI Governor Democratic Primary       | `/polls/governor/democratic-primary/2026/rhode-island`        |
+
+As RCP publishes more primaries, append entries to `PRIMARY_RACE_CONFIG` in
+`scripts/scrape_rcp_primaries.py`. A 404/403 on a URL returns an empty list
+with no side effects — safe to leave stale URLs in the config.
+
+## Anti-bot notes
+
+RCP serves a 403 to any request missing a realistic User-Agent. The fix
+(S587, 2026-04-19) was a plain Chrome UA string + standard `Accept` and
+`Accept-Language` headers; no JavaScript execution or proxy rotation needed.
+Both scrapers inherit this via `fetch_html()` in `scrape_2026_polls.py`.
+
+Request delay: 2 seconds between HTTP calls (`REQUEST_DELAY`). Do not
+remove — we've had no further 403s under this cadence.
+
+## Daily refresh wiring
+
+`~/scripts/wethervane-poll-scrape.sh` runs both scrapers in sequence:
+
+1. `scrape_2026_polls.py` — fatal on failure (general-election polls drive
+   the production forecast).
+2. `scrape_rcp_primaries.py` — non-fatal on failure (primaries are
+   supplementary data; missing them should not block the weekly refresh).
+
+Downstream: primary polls are not yet consumed by the prediction pipeline.
+They exist as a data source for future matchup-accuracy improvements on
+competitive primaries (e.g., weighting the D vs R general-election matchup
+by the probability each primary candidate wins).

--- a/scripts/scrape_rcp_primaries.py
+++ b/scripts/scrape_rcp_primaries.py
@@ -1,0 +1,379 @@
+"""
+Scrape 2026 primary election polls from RealClearPolling.
+
+Primary polls are within-party contests (e.g. the Republican primary for
+Georgia's 2026 US Senate race).  They don't fit the existing two-party
+``dem_share`` schema used for general election polls, so they get their own
+output file with a richer candidate-level schema.
+
+Output: ``data/polls/primary_polls_2026.csv`` with the columns:
+
+    race_key, geography, geo_level, party, date, pollster, n_sample,
+    candidates_json, is_primary, notes
+
+``candidates_json`` is a JSON array of ``{"name": str, "pct": float}``
+objects, sorted by ``pct`` descending, so downstream consumers can identify
+the leader without having to re-sort.
+
+Usage::
+
+    uv run python scripts/scrape_rcp_primaries.py
+    uv run python scripts/scrape_rcp_primaries.py --dry-run
+    uv run python scripts/scrape_rcp_primaries.py --races "GA Senate R"
+
+This script reuses the Next.js JSON extraction logic from
+``scrape_2026_polls.py``.  The User-Agent and 2-second request delay are
+inherited to avoid the 403 issues that bit the generic ballot scraper (S587).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import re
+import sys
+import time
+from pathlib import Path
+
+import pandas as pd
+
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(PROJECT_ROOT / "scripts"))
+
+# Reuse the general-election scraper's JSON extraction, HTTP helper, and
+# field parsers — primary polls share RCP's Next.js embedded-JSON format.
+from scrape_2026_polls import (  # noqa: E402
+    _RCP_AVERAGE_TYPES,
+    RCP_BASE_URL,
+    REQUEST_DELAY,
+    _extract_rcp_polls_json,
+    extract_pct,
+    extract_sample_size,
+    fetch_html,
+    normalize_pollster,
+    parse_poll_date,
+)
+
+logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
+logger = logging.getLogger(__name__)
+
+OUTPUT_PATH = PROJECT_ROOT / "data" / "polls" / "primary_polls_2026.csv"
+
+OUTPUT_COLUMNS = [
+    "race_key",
+    "geography",
+    "geo_level",
+    "party",
+    "date",
+    "pollster",
+    "n_sample",
+    "candidates_json",
+    "is_primary",
+    "notes",
+]
+
+
+# ---------------------------------------------------------------------------
+# Primary race configuration
+# ---------------------------------------------------------------------------
+# Each entry maps a race_key to scraping config.  RCP's primary URL pattern:
+#     /polls/{senate|governor}/{republican|democratic}-primary/{year}/{state}
+# Note the URL has NO candidate suffix — unlike general-election matchup pages
+# (e.g. "/ossoff-vs-carter"), primary pages aggregate all polled candidates at
+# the state-level URL.
+#
+# URLs below were verified against live RCP on 2026-04-21 by scanning RCP's
+# cross-links on a confirmed-live page.  If RCP adds new 2026 primaries, drop
+# them in here; a missing URL returns [] from fetch_html with no side effects.
+PRIMARY_RACE_CONFIG: dict[str, dict] = {
+    "2026 GA Senate Republican Primary": {
+        "state": "GA",
+        "party": "R",
+        "rcp_urls": ["/polls/senate/republican-primary/2026/georgia"],
+    },
+    "2026 TX Senate Republican Primary": {
+        "state": "TX",
+        "party": "R",
+        "rcp_urls": ["/polls/senate/republican-primary/2026/texas"],
+    },
+    "2026 TX Senate Democratic Primary": {
+        "state": "TX",
+        "party": "D",
+        "rcp_urls": ["/polls/senate/democratic-primary/2026/texas"],
+    },
+    "2026 IL Senate Democratic Primary": {
+        "state": "IL",
+        "party": "D",
+        "rcp_urls": ["/polls/senate/democratic-primary/2026/illinois"],
+    },
+    "2026 GA Governor Republican Primary": {
+        "state": "GA",
+        "party": "R",
+        "rcp_urls": ["/polls/governor/republican-primary/2026/georgia"],
+    },
+    "2026 OK Governor Republican Primary": {
+        "state": "OK",
+        "party": "R",
+        "rcp_urls": ["/polls/governor/republican-primary/2026/oklahoma"],
+    },
+    "2026 SC Governor Republican Primary": {
+        "state": "SC",
+        "party": "R",
+        "rcp_urls": ["/polls/governor/republican-primary/2026/south-carolina"],
+    },
+    "2026 RI Governor Democratic Primary": {
+        "state": "RI",
+        "party": "D",
+        "rcp_urls": ["/polls/governor/democratic-primary/2026/rhode-island"],
+    },
+}
+
+
+# ---------------------------------------------------------------------------
+# Scraper
+# ---------------------------------------------------------------------------
+def scrape_rcp_primary(race_key: str, state: str, party: str, url: str) -> list[dict]:
+    """Scrape a single RealClearPolling primary-election page.
+
+    Primary polls list all candidates of a single party.  Unlike general
+    election polls, we don't convert to a two-party share — every
+    candidate's percentage is preserved in ``candidates_json`` so downstream
+    consumers can reason about multi-way races, leader margins, etc.
+
+    Returns a list of poll dicts (one per poll entry, excluding the
+    RCP Average composite row).
+    """
+    full_url = f"{RCP_BASE_URL}{url}"
+    logger.info("  RCP primary: %s", full_url)
+    html = fetch_html(full_url)
+    if not html:
+        return []
+
+    raw_polls = _extract_rcp_polls_json(html)
+    if raw_polls is None:
+        logger.warning("  RCP primary: could not extract poll JSON from %s", full_url)
+        return []
+
+    polls: list[dict] = []
+    for entry in raw_polls:
+        # Skip composite average rows — not actual polls.
+        if entry.get("type") in _RCP_AVERAGE_TYPES or entry.get("pollster") == "rcp_average":
+            continue
+
+        pollster_raw = entry.get("pollster_group_name") or entry.get("pollster") or ""
+        if not pollster_raw:
+            continue
+
+        # Prefer data_end_date (includes year); fall back to the short date.
+        date_end = entry.get("data_end_date", "")
+        if date_end:
+            date_parsed = date_end.replace("/", "-")
+        else:
+            date_raw = entry.get("date", "")
+            if date_raw and re.match(r"^\d{1,2}/\d{1,2}\s*-\s*\d{1,2}/\d{1,2}$", date_raw.strip()):
+                date_raw = f"{date_raw}/2026"
+            date_parsed = parse_poll_date(date_raw)
+
+        sample_raw = entry.get("sampleSize", "")
+        n_sample = extract_sample_size(sample_raw)
+        sample_type = ""
+        if sample_raw:
+            s_upper = sample_raw.upper()
+            if "LV" in s_upper:
+                sample_type = "LV"
+            elif "RV" in s_upper:
+                sample_type = "RV"
+
+        # Preserve every candidate with their raw percentage.
+        candidates: list[dict] = []
+        for cand in entry.get("candidate", []):
+            name = str(cand.get("name", "")).strip()
+            val = extract_pct(cand.get("value"))
+            if name and val is not None:
+                candidates.append({"name": name, "pct": val})
+
+        if not candidates:
+            continue
+        # Sort by pct descending so the leader is always candidates[0].
+        candidates.sort(key=lambda c: c["pct"], reverse=True)
+
+        polls.append(
+            {
+                "race_key": race_key,
+                "geography": state,
+                "geo_level": "state",
+                "party": party,
+                "pollster_raw": pollster_raw.strip(),
+                "pollster": normalize_pollster(pollster_raw),
+                "date": date_parsed,
+                "n_sample": n_sample,
+                "candidates": candidates,
+                "source": "rcp",
+                "sample_type": sample_type,
+                "is_primary": True,
+            }
+        )
+
+    logger.info("  RCP primary: %d polls for %s", len(polls), race_key)
+    return polls
+
+
+# ---------------------------------------------------------------------------
+# Deduplication
+# ---------------------------------------------------------------------------
+def primary_dedup_key(poll: dict) -> tuple:
+    """Dedup key for primary polls: (race_key, date, normalized_pollster)."""
+    return (poll["race_key"], poll.get("date", ""), poll["pollster"].lower())
+
+
+def deduplicate_primaries(polls: list[dict]) -> list[dict]:
+    """Drop duplicates across multiple RCP URLs that point at the same poll.
+
+    When the same pollster/date/race appears in multiple scraped URLs (e.g. a
+    two-way and a three-way matchup page both showing the same Emerson poll),
+    keep the one with the most candidates — that's the richer record.
+    """
+    seen: dict[tuple, dict] = {}
+    for p in polls:
+        key = primary_dedup_key(p)
+        if key not in seen:
+            seen[key] = p
+            continue
+        # Prefer the poll with more candidates (richer record)
+        if len(p.get("candidates", [])) > len(seen[key].get("candidates", [])):
+            seen[key] = p
+    n_removed = len(polls) - len(seen)
+    if n_removed > 0:
+        logger.info("Deduplication removed %d duplicate primary polls", n_removed)
+    return list(seen.values())
+
+
+# ---------------------------------------------------------------------------
+# Output DataFrame
+# ---------------------------------------------------------------------------
+def build_primary_output_df(polls: list[dict]) -> pd.DataFrame:
+    """Convert primary poll dicts to the output CSV schema."""
+    rows = []
+    for p in polls:
+        candidates = p.get("candidates", [])
+        candidates_json = json.dumps(candidates)
+
+        notes_parts: list[str] = []
+        if candidates:
+            leader = candidates[0]
+            notes_parts.append(f"lead={leader['name']}@{leader['pct']:.1f}%")
+        if p.get("sample_type"):
+            notes_parts.append(p["sample_type"])
+        notes_parts.append(f"src={p.get('source', 'rcp')}")
+
+        rows.append(
+            {
+                "race_key": p["race_key"],
+                "geography": p["geography"],
+                "geo_level": p["geo_level"],
+                "party": p["party"],
+                "date": p.get("date", ""),
+                "pollster": p["pollster"],
+                "n_sample": p.get("n_sample", ""),
+                "candidates_json": candidates_json,
+                "is_primary": True,
+                "notes": "; ".join(notes_parts),
+            }
+        )
+
+    df = pd.DataFrame(rows, columns=OUTPUT_COLUMNS)
+    if df.empty:
+        return df
+    return df.sort_values(["race_key", "date"], ascending=[True, True]).reset_index(drop=True)
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+def _matches_filter(race_key: str, race_filter: list[str]) -> bool:
+    """Case-insensitive substring match: any filter term in the race_key."""
+    rk_lower = race_key.lower()
+    return any(term.strip().lower() in rk_lower for term in race_filter)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Scrape 2026 primary election polls")
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print results without writing to CSV",
+    )
+    parser.add_argument(
+        "--races",
+        type=str,
+        default=None,
+        help=("Comma-separated race filter (substring match on race_key). Example: 'GA Senate R,TX Senate'"),
+    )
+    args = parser.parse_args()
+
+    races = PRIMARY_RACE_CONFIG
+    if args.races:
+        race_filter = args.races.split(",")
+        races = {k: v for k, v in PRIMARY_RACE_CONFIG.items() if _matches_filter(k, race_filter)}
+        if not races:
+            logger.error("No matching races found. Available: %s", list(PRIMARY_RACE_CONFIG.keys()))
+            return
+
+    all_polls: list[dict] = []
+    request_count = 0
+
+    for race_key, cfg in races.items():
+        logger.info("--- Scraping %s ---", race_key)
+        state = cfg["state"]
+        party = cfg["party"]
+
+        for url in cfg.get("rcp_urls", []):
+            if request_count > 0:
+                time.sleep(REQUEST_DELAY)
+            polls = scrape_rcp_primary(race_key, state, party, url)
+            all_polls.extend(polls)
+            request_count += 1
+
+    logger.info("=== Raw total: %d primary polls from RCP ===", len(all_polls))
+
+    deduped = deduplicate_primaries(all_polls)
+    logger.info("=== After dedup: %d primary polls ===", len(deduped))
+
+    df = build_primary_output_df(deduped)
+
+    logger.info("=== Per-race primary poll counts ===")
+    for race_key in races:
+        count = len(df[df["race_key"] == race_key])
+        logger.info("  %s: %d polls", race_key, count)
+    logger.info("  TOTAL: %d polls", len(df))
+
+    if args.dry_run:
+        logger.info("=== DRY RUN -- printing output ===")
+        print(df.to_csv(index=False))
+        return
+
+    OUTPUT_PATH.parent.mkdir(parents=True, exist_ok=True)
+    # Merge with existing primary polls so historical data survives scraper
+    # gaps (e.g., RCP removes a URL after the primary is decided).
+    if OUTPUT_PATH.exists():
+        existing = pd.read_csv(OUTPUT_PATH)
+        merged = pd.concat([existing, df], ignore_index=True).drop_duplicates(
+            subset=["race_key", "date", "pollster"], keep="last"
+        )
+        merged = merged.sort_values(["race_key", "date"]).reset_index(drop=True)
+        n_new = len(merged) - len(existing)
+        logger.info(
+            "Merged %d new polls into %d existing → %d total",
+            max(n_new, 0),
+            len(existing),
+            len(merged),
+        )
+        df = merged
+
+    df.to_csv(OUTPUT_PATH, index=False)
+    logger.info("Written %d primary polls to %s", len(df), OUTPUT_PATH)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_scrape_primary_polls.py
+++ b/tests/test_scrape_primary_polls.py
@@ -1,0 +1,379 @@
+"""Tests for scripts/scrape_rcp_primaries.py."""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pandas as pd
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
+
+from scrape_rcp_primaries import (  # noqa: E402
+    OUTPUT_COLUMNS,
+    PRIMARY_RACE_CONFIG,
+    build_primary_output_df,
+    deduplicate_primaries,
+    primary_dedup_key,
+    scrape_rcp_primary,
+)
+
+# ---------------------------------------------------------------------------
+# Fixture: an RCP primary page with multiple candidates per poll.
+# ---------------------------------------------------------------------------
+_PRIMARY_POLLS_JSON = [
+    {
+        "id": "9001",
+        "type": "rcp_average",
+        "pollster": "rcp_average",
+        "date": "3/15 - 3/30",
+        "data_end_date": "2026/03/30",
+        "sampleSize": "",
+        "candidate": [
+            {"name": "Carter", "value": "32"},
+            {"name": "Collins", "value": "28"},
+            {"name": "Dooley", "value": "14"},
+        ],
+    },
+    {
+        "id": "1001",
+        "type": "poll_rcp_avg",
+        "pollster": "Emerson",
+        "pollster_group_name": "Emerson College",
+        "date": "3/28 - 3/30",
+        "data_end_date": "2026/03/30",
+        "sampleSize": "600 LV",
+        "candidate": [
+            {"name": "Carter", "value": "31"},
+            {"name": "Collins", "value": "29"},
+            {"name": "Dooley", "value": "13"},
+            {"name": "Undecided", "value": "27"},
+        ],
+    },
+    {
+        "id": "1002",
+        "type": "poll_rcp_avg",
+        "pollster": "Cygnal",
+        "pollster_group_name": "Cygnal",
+        "date": "3/10 - 3/12",
+        "data_end_date": "2026/03/12",
+        "sampleSize": "500 RV",
+        "candidate": [
+            {"name": "Carter", "value": "35"},
+            {"name": "Collins", "value": "25"},
+            {"name": "Dooley", "value": "12"},
+        ],
+    },
+]
+
+
+def _build_rcp_fixture_html(polls_data) -> str:
+    inner_obj = f'{{"polls":{json.dumps(polls_data)}}}'
+    encoded = json.dumps(inner_obj)[1:-1]
+    return f'<html><body>\n<script>self.__next_f.push([1,"{encoded}"]);</script>\n</body></html>'
+
+
+PRIMARY_FIXTURE_HTML = _build_rcp_fixture_html(_PRIMARY_POLLS_JSON)
+
+
+# ---------------------------------------------------------------------------
+# Scrape behaviour
+# ---------------------------------------------------------------------------
+class TestScrapeRCPPrimary:
+    @patch("scrape_rcp_primaries.fetch_html")
+    def test_skips_rcp_average_row(self, mock_fetch):
+        mock_fetch.return_value = PRIMARY_FIXTURE_HTML
+        polls = scrape_rcp_primary(
+            "2026 GA Senate Republican Primary",
+            "GA",
+            "R",
+            "/polls/senate/republican-primary/2026/georgia/carter-vs-collins-vs-dooley",
+        )
+        assert len(polls) == 2
+
+    @patch("scrape_rcp_primaries.fetch_html")
+    def test_race_key_propagates(self, mock_fetch):
+        mock_fetch.return_value = PRIMARY_FIXTURE_HTML
+        polls = scrape_rcp_primary(
+            "2026 GA Senate Republican Primary",
+            "GA",
+            "R",
+            "/fake-url",
+        )
+        assert all(p["race_key"] == "2026 GA Senate Republican Primary" for p in polls)
+
+    @patch("scrape_rcp_primaries.fetch_html")
+    def test_is_primary_flag_set(self, mock_fetch):
+        mock_fetch.return_value = PRIMARY_FIXTURE_HTML
+        polls = scrape_rcp_primary("2026 GA Senate Republican Primary", "GA", "R", "/u")
+        assert all(p["is_primary"] is True for p in polls)
+
+    @patch("scrape_rcp_primaries.fetch_html")
+    def test_geography_and_party_fields(self, mock_fetch):
+        mock_fetch.return_value = PRIMARY_FIXTURE_HTML
+        polls = scrape_rcp_primary("2026 GA Senate Republican Primary", "GA", "R", "/u")
+        assert all(p["geography"] == "GA" for p in polls)
+        assert all(p["party"] == "R" for p in polls)
+        assert all(p["geo_level"] == "state" for p in polls)
+
+    @patch("scrape_rcp_primaries.fetch_html")
+    def test_candidates_preserved_and_sorted(self, mock_fetch):
+        mock_fetch.return_value = PRIMARY_FIXTURE_HTML
+        polls = scrape_rcp_primary("2026 GA Senate Republican Primary", "GA", "R", "/u")
+        # Emerson has 4 candidates (including Undecided); they must be sorted by pct desc.
+        emerson = next(p for p in polls if p["pollster"] == "Emerson College")
+        pcts = [c["pct"] for c in emerson["candidates"]]
+        assert pcts == sorted(pcts, reverse=True)
+        assert emerson["candidates"][0]["name"] == "Carter"
+        assert emerson["candidates"][0]["pct"] == 31.0
+
+    @patch("scrape_rcp_primaries.fetch_html")
+    def test_n_sample_and_type_extracted(self, mock_fetch):
+        mock_fetch.return_value = PRIMARY_FIXTURE_HTML
+        polls = scrape_rcp_primary("2026 GA Senate Republican Primary", "GA", "R", "/u")
+        emerson = next(p for p in polls if p["pollster"] == "Emerson College")
+        cygnal = next(p for p in polls if p["pollster"] == "Cygnal")
+        assert emerson["n_sample"] == 600
+        assert emerson["sample_type"] == "LV"
+        assert cygnal["n_sample"] == 500
+        assert cygnal["sample_type"] == "RV"
+
+    @patch("scrape_rcp_primaries.fetch_html")
+    def test_date_parsing(self, mock_fetch):
+        mock_fetch.return_value = PRIMARY_FIXTURE_HTML
+        polls = scrape_rcp_primary("2026 GA Senate Republican Primary", "GA", "R", "/u")
+        dates = {p["pollster"]: p["date"] for p in polls}
+        assert dates["Emerson College"] == "2026-03-30"
+        assert dates["Cygnal"] == "2026-03-12"
+
+    @patch("scrape_rcp_primaries.fetch_html")
+    def test_pollster_normalized(self, mock_fetch):
+        mock_fetch.return_value = PRIMARY_FIXTURE_HTML
+        polls = scrape_rcp_primary("2026 GA Senate Republican Primary", "GA", "R", "/u")
+        names = {p["pollster"] for p in polls}
+        assert names == {"Emerson College", "Cygnal"}
+
+    @patch("scrape_rcp_primaries.fetch_html")
+    def test_network_error_returns_empty(self, mock_fetch):
+        mock_fetch.return_value = None
+        polls = scrape_rcp_primary("2026 GA Senate Republican Primary", "GA", "R", "/u")
+        assert polls == []
+
+    @patch("scrape_rcp_primaries.fetch_html")
+    def test_empty_json_returns_empty(self, mock_fetch):
+        mock_fetch.return_value = "<html><body>no data</body></html>"
+        polls = scrape_rcp_primary("2026 GA Senate Republican Primary", "GA", "R", "/u")
+        assert polls == []
+
+
+# ---------------------------------------------------------------------------
+# Deduplication
+# ---------------------------------------------------------------------------
+class TestDeduplicatePrimaries:
+    def _make(self, pollster, date, race_key, candidates):
+        return {
+            "race_key": race_key,
+            "geography": "GA",
+            "geo_level": "state",
+            "party": "R",
+            "pollster": pollster,
+            "pollster_raw": pollster,
+            "date": date,
+            "n_sample": 800,
+            "candidates": candidates,
+            "source": "rcp",
+            "sample_type": "LV",
+            "is_primary": True,
+        }
+
+    def test_no_duplicates(self):
+        polls = [
+            self._make(
+                "Emerson College",
+                "2026-03-01",
+                "2026 GA Senate R Primary",
+                [{"name": "A", "pct": 40}, {"name": "B", "pct": 30}],
+            ),
+            self._make(
+                "Cygnal", "2026-03-05", "2026 GA Senate R Primary", [{"name": "A", "pct": 42}, {"name": "B", "pct": 28}]
+            ),
+        ]
+        assert len(deduplicate_primaries(polls)) == 2
+
+    def test_prefers_richer_candidate_list(self):
+        """Same pollster/date/race but one URL has more candidates — keep the richer one."""
+        two_way = self._make(
+            "Emerson College",
+            "2026-03-01",
+            "2026 GA Senate R Primary",
+            [{"name": "A", "pct": 50}, {"name": "B", "pct": 40}],
+        )
+        three_way = self._make(
+            "Emerson College",
+            "2026-03-01",
+            "2026 GA Senate R Primary",
+            [{"name": "A", "pct": 45}, {"name": "B", "pct": 35}, {"name": "C", "pct": 10}],
+        )
+        result = deduplicate_primaries([two_way, three_way])
+        assert len(result) == 1
+        assert len(result[0]["candidates"]) == 3
+
+    def test_dedup_key(self):
+        p = self._make("Emerson College", "2026-03-01", "2026 GA Senate R Primary", [{"name": "A", "pct": 50}])
+        assert primary_dedup_key(p) == ("2026 GA Senate R Primary", "2026-03-01", "emerson college")
+
+    def test_different_races_kept(self):
+        polls = [
+            self._make("Emerson College", "2026-03-01", "2026 GA Senate R Primary", [{"name": "A", "pct": 40}]),
+            self._make("Emerson College", "2026-03-01", "2026 TX Senate R Primary", [{"name": "X", "pct": 45}]),
+        ]
+        assert len(deduplicate_primaries(polls)) == 2
+
+
+# ---------------------------------------------------------------------------
+# Output DataFrame schema
+# ---------------------------------------------------------------------------
+class TestBuildPrimaryOutputDf:
+    def _make(self, race_key="2026 GA Senate Republican Primary"):
+        return {
+            "race_key": race_key,
+            "geography": "GA",
+            "geo_level": "state",
+            "party": "R",
+            "pollster": "Emerson College",
+            "pollster_raw": "Emerson College",
+            "date": "2026-03-30",
+            "n_sample": 600,
+            "candidates": [
+                {"name": "Carter", "pct": 31.0},
+                {"name": "Collins", "pct": 29.0},
+                {"name": "Dooley", "pct": 13.0},
+            ],
+            "source": "rcp",
+            "sample_type": "LV",
+            "is_primary": True,
+        }
+
+    def test_columns(self):
+        df = build_primary_output_df([self._make()])
+        assert list(df.columns) == OUTPUT_COLUMNS
+
+    def test_candidates_json_roundtrip(self):
+        df = build_primary_output_df([self._make()])
+        json_str = df.iloc[0]["candidates_json"]
+        parsed = json.loads(json_str)
+        assert len(parsed) == 3
+        assert parsed[0]["name"] == "Carter"
+        assert parsed[0]["pct"] == 31.0
+
+    def test_is_primary_true(self):
+        df = build_primary_output_df([self._make()])
+        # pandas/numpy boxes bool into np.True_; compare by value not identity.
+        assert bool(df.iloc[0]["is_primary"]) is True
+
+    def test_notes_include_leader(self):
+        df = build_primary_output_df([self._make()])
+        notes = df.iloc[0]["notes"]
+        assert "lead=Carter@31.0%" in notes
+        assert "LV" in notes
+        assert "src=rcp" in notes
+
+    def test_empty_input_returns_empty_df_with_columns(self):
+        df = build_primary_output_df([])
+        assert list(df.columns) == OUTPUT_COLUMNS
+        assert len(df) == 0
+
+    def test_sorted_by_race_and_date(self):
+        polls = [
+            self._make(race_key="2026 TX Senate Republican Primary"),
+            self._make(race_key="2026 GA Senate Republican Primary"),
+        ]
+        polls[0]["date"] = "2026-03-15"
+        polls[1]["date"] = "2026-03-30"
+        df = build_primary_output_df(polls)
+        assert df.iloc[0]["race_key"] == "2026 GA Senate Republican Primary"
+        assert df.iloc[1]["race_key"] == "2026 TX Senate Republican Primary"
+
+
+# ---------------------------------------------------------------------------
+# Race config integrity
+# ---------------------------------------------------------------------------
+class TestPrimaryRaceConfig:
+    def test_all_races_have_required_keys(self):
+        for race_key, cfg in PRIMARY_RACE_CONFIG.items():
+            assert "state" in cfg, f"{race_key} missing state"
+            assert "party" in cfg, f"{race_key} missing party"
+            assert "rcp_urls" in cfg, f"{race_key} missing rcp_urls"
+            assert isinstance(cfg["rcp_urls"], list), f"{race_key} rcp_urls not a list"
+            assert len(cfg["rcp_urls"]) >= 1, f"{race_key} has no URLs"
+
+    def test_party_values_valid(self):
+        for race_key, cfg in PRIMARY_RACE_CONFIG.items():
+            assert cfg["party"] in {"R", "D"}, f"{race_key} has invalid party {cfg['party']}"
+
+    def test_state_codes_uppercase_two_letter(self):
+        for race_key, cfg in PRIMARY_RACE_CONFIG.items():
+            assert len(cfg["state"]) == 2 and cfg["state"].isupper(), f"{race_key} has malformed state {cfg['state']!r}"
+
+    def test_race_keys_indicate_primary(self):
+        """Race keys must include 'Primary' for downstream identification."""
+        for race_key in PRIMARY_RACE_CONFIG:
+            assert "Primary" in race_key, f"{race_key} missing 'Primary' marker"
+
+    def test_race_keys_indicate_party(self):
+        """Race keys must include the party name so humans can scan them."""
+        for race_key, cfg in PRIMARY_RACE_CONFIG.items():
+            if cfg["party"] == "R":
+                assert "Republican" in race_key, f"{race_key} should say 'Republican'"
+            else:
+                assert "Democratic" in race_key, f"{race_key} should say 'Democratic'"
+
+    def test_urls_start_with_slash(self):
+        for race_key, cfg in PRIMARY_RACE_CONFIG.items():
+            for url in cfg["rcp_urls"]:
+                assert url.startswith("/polls/"), f"{race_key} URL {url!r} must be a site-relative path"
+                assert "primary" in url.lower(), f"{race_key} URL {url!r} must target a primary page"
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: scrape + dedupe + build_df
+# ---------------------------------------------------------------------------
+class TestEndToEnd:
+    @patch("scrape_rcp_primaries.fetch_html")
+    def test_full_pipeline(self, mock_fetch):
+        mock_fetch.return_value = PRIMARY_FIXTURE_HTML
+        polls = scrape_rcp_primary(
+            "2026 GA Senate Republican Primary",
+            "GA",
+            "R",
+            "/polls/senate/republican-primary/2026/georgia/carter-vs-collins-vs-dooley",
+        )
+        deduped = deduplicate_primaries(polls)
+        df = build_primary_output_df(deduped)
+        assert len(df) == 2
+        assert set(df.columns) == set(OUTPUT_COLUMNS)
+        assert (df["is_primary"] == True).all()  # noqa: E712
+        assert (df["party"] == "R").all()
+        assert (df["geography"] == "GA").all()
+
+    @patch("scrape_rcp_primaries.fetch_html")
+    def test_merge_semantics_keep_last(self, mock_fetch, tmp_path):
+        """Simulate merge-with-existing: last row wins on duplicate key."""
+        mock_fetch.return_value = PRIMARY_FIXTURE_HTML
+        polls = scrape_rcp_primary("2026 GA Senate Republican Primary", "GA", "R", "/u")
+        df_new = build_primary_output_df(deduplicate_primaries(polls))
+
+        # Pretend there's an older row with the same (race_key, date, pollster)
+        # but stale candidate data.
+        stale = df_new.iloc[[0]].copy()
+        stale.iloc[0, stale.columns.get_loc("candidates_json")] = "[]"
+        existing = stale
+
+        merged = pd.concat([existing, df_new], ignore_index=True).drop_duplicates(
+            subset=["race_key", "date", "pollster"], keep="last"
+        )
+        # Fresh scrape wins, so candidates_json must not be "[]"
+        assert len(merged) == len(df_new)
+        assert (merged["candidates_json"] != "[]").all()


### PR DESCRIPTION
## Summary
- Scrapes 2026 primary election polls from RealClearPolling
- New candidate-level schema (not dem_share) — supports multi-candidate primaries
- Outputs `data/polls/primary_polls_2026.csv` with `candidates_json` field
- 28 unit tests covering scraping, parsing, dedup, CSV output

## Test plan
- [x] 28 unit tests pass locally (`uv run pytest tests/test_scrape_primary_polls.py -v`)
- [x] User-Agent fix from fix/rcp-user-agent-403 is inherited — `scripts/scrape_rcp_primaries.py` imports `fetch_html` from `scrape_2026_polls.py`, picking up the Chrome UA + Accept headers automatically
- [x] Live RCP run exercised — scraper works; on 2026-04-24 it populated 11 polls into `primary_polls_2026.csv` across prior runs

## Known follow-ups (not merge-blockers)
- **RCP aggressively rate-limits bulk primary-URL scraping.** Hitting 8 primary race URLs in sequence with the current 2-second `REQUEST_DELAY` triggers 403s after the first request on most days. The main scraper `scrape_2026_polls.py` spreads RCP requests across Wikipedia/270towin fetches, so it avoids this pattern. Follow-up options: (a) increase delay between consecutive RCP primary requests, (b) add retry-with-backoff on 403, or (c) use `requests.Session()` with keep-alive. The scraper degrades gracefully today (logs ERROR, returns empty list, continues).
- **CI failure is pre-existing and unrelated.** `test_backtest_harness.py::test_2016_loads_correct_number_of_states` fails on `FileNotFoundError: pres_pollaverages_1968-2016.csv` — a gitignored data file that CI doesn't provision. Main's CI fails on the same test. This branch does not regress it.