### PR TITLE
feat(polls): Quantus Insights crosstab parser

### DIFF
--- a/scripts/parse_quantus_report.py
+++ b/scripts/parse_quantus_report.py
@@ -1,0 +1,313 @@
+"""
+Parse Quantus Insights crosstab reports to extract per-group vote shares and
+sample-composition demographics.
+
+Quantus publishes crosstabs in several channels: Substack posts with inline
+HTML tables, PDF reports linked from their site, and a JS-rendered polls
+portal at polls.quantusinsights.org.  The portal is behind a Vercel bot
+challenge so cannot be fetched without a browser.  Substack and PDF reports
+collapse cleanly to plain text when extracted with pdfplumber or BeautifulSoup
+— and in both cases the crosstab table renders as one row per demographic
+group with two or three trailing percentages (Dem, Rep, and optionally
+Undecided/Other).
+
+This parser is therefore **text-in, dict-out**: callers are responsible for
+turning the source artifact into text (``pdfplumber.Page.extract_text()`` for
+PDFs, ``BeautifulSoup.get_text()`` for Substack HTML, or just ``open().read()``
+for saved fixtures).  Keeping the pattern-matching layer pure means the tests
+do not depend on any specific extraction backend.
+
+Two kinds of output:
+
+1. **Crosstab vote shares** (``xt_vote_*``): per-demographic two-party
+   Democratic share for the headline ballot question.  Drives Tier 1 W-vector
+   construction in ``src/prediction/forecast_engine.py``.
+2. **Sample composition** (``xt_*``): weighted fraction of the poll sample in
+   each demographic group.  Required for Tier 2 observations.
+
+Column names match the canonical set used by the Emerson scraper and the
+Marist PDF parser so the downstream pipeline does not need pollster-specific
+branches.
+
+Usage:
+    uv run python scripts/parse_quantus_report.py path/to/quantus_report.txt
+    uv run python scripts/parse_quantus_report.py path/to/quantus_report.pdf
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import re
+import sys
+from pathlib import Path
+from typing import Optional
+
+logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
+logger = logging.getLogger(__name__)
+
+
+# Canonical label → xt_vote_* column name.  Keys are normalized (lowercase,
+# whitespace collapsed) so we can match labels that appear with varying case
+# and spacing in the source text.  When multiple raw labels map to the same
+# canonical group (e.g., "65+" and "65 or older"), list each one.
+VOTE_LABEL_MAP: dict[str, str] = {
+    "white": "xt_vote_race_white",
+    "black": "xt_vote_race_black",
+    "african american": "xt_vote_race_black",
+    "hispanic": "xt_vote_race_hispanic",
+    "latino": "xt_vote_race_hispanic",
+    "asian": "xt_vote_race_asian",
+    "college graduate": "xt_vote_education_college",
+    "college": "xt_vote_education_college",
+    "college grad": "xt_vote_education_college",
+    "4-year college": "xt_vote_education_college",
+    "no college": "xt_vote_education_noncollege",
+    "non-college": "xt_vote_education_noncollege",
+    "not college graduate": "xt_vote_education_noncollege",
+    "65+": "xt_vote_age_senior",
+    "65 or older": "xt_vote_age_senior",
+    "65 and older": "xt_vote_age_senior",
+    "urban": "xt_vote_urbanicity_urban",
+    "rural": "xt_vote_urbanicity_rural",
+}
+
+# Canonical label → xt_* sample composition column name.  Same label keys as
+# VOTE_LABEL_MAP but the output column names omit the ``_vote_`` infix.
+COMPOSITION_LABEL_MAP: dict[str, str] = {
+    "white": "xt_race_white",
+    "black": "xt_race_black",
+    "african american": "xt_race_black",
+    "hispanic": "xt_race_hispanic",
+    "latino": "xt_race_hispanic",
+    "asian": "xt_race_asian",
+    "college graduate": "xt_education_college",
+    "college": "xt_education_college",
+    "college grad": "xt_education_college",
+    "4-year college": "xt_education_college",
+    "no college": "xt_education_noncollege",
+    "non-college": "xt_education_noncollege",
+    "not college graduate": "xt_education_noncollege",
+    "65+": "xt_age_senior",
+    "65 or older": "xt_age_senior",
+    "65 and older": "xt_age_senior",
+    "urban": "xt_urbanicity_urban",
+    "rural": "xt_urbanicity_rural",
+}
+
+# Regex for a crosstab vote row — a label followed by at least two trailing
+# percentages (Dem, Rep) and optionally a third (Undecided/Other).  The
+# single-column composition row uses a separate regex below.
+#
+# We capture up to four percentages and let the caller decide which to use;
+# this lets the same function cope with Quantus's common "D/R/Und" triple and
+# with occasional four-column publications that add Other.
+_VOTE_ROW = re.compile(
+    r"^(?P<label>.+?)\s+"
+    r"(?P<d>\d+)%\s+"
+    r"(?P<r>\d+)%"
+    r"(?:\s+\d+%){0,2}"
+    r"\s*$"
+)
+
+# Regex for a sample-composition row — a label followed by exactly one
+# trailing percentage.
+_SINGLE_PCT_ROW = re.compile(r"^(?P<label>.+?)\s+(?P<pct>\d+)%\s*$")
+
+# Heading lines that introduce the sample-composition table.  We only parse
+# single-percentage rows after one of these headers has been seen, so that an
+# incidental "Total 100%" line elsewhere in the document is not misread.
+_COMPOSITION_HEADERS = (
+    "SAMPLE COMPOSITION",
+    "NATURE OF THE SAMPLE",
+    "WEIGHTED SAMPLE",
+)
+
+
+def two_party_dem_share(dem_pct: float, rep_pct: float) -> Optional[float]:
+    """Convert raw percentages to two-party Democratic share.
+
+    Args:
+        dem_pct: Democratic candidate percentage (0-100 scale).
+        rep_pct: Republican candidate percentage (0-100 scale).
+
+    Returns:
+        Two-party share as a float in [0, 1], or None if both are zero.
+    """
+    if dem_pct + rep_pct == 0:
+        return None
+    return dem_pct / (dem_pct + rep_pct)
+
+
+def _normalize_label(label: str) -> str:
+    """Lowercase, strip, and collapse whitespace for robust label matching."""
+    return re.sub(r"\s+", " ", label.strip().lower())
+
+
+def parse_quantus_crosstab_text(text: str) -> dict[str, Optional[float]]:
+    """Parse crosstab vote-share text into an ``xt_vote_*`` dict.
+
+    Expects the Quantus demographic crosstab laid out one group per line, with
+    the Democratic candidate in the first percentage column and the Republican
+    candidate in the second.  Additional trailing columns (Undecided, Other)
+    are ignored.
+
+    An "Overall" / "All voters" / "Total" row produces a ``dem_share_topline``
+    entry so callers can sanity-check against the published headline number.
+
+    Args:
+        text: Raw crosstab text.
+
+    Returns:
+        Dict mapping ``xt_vote_*`` column names to two-party Dem share values
+        in [0, 1], plus optionally ``dem_share_topline``.
+    """
+    result: dict[str, Optional[float]] = {}
+
+    for raw_line in text.split("\n"):
+        match = _VOTE_ROW.match(raw_line.strip())
+        if not match:
+            continue
+
+        label = _normalize_label(match.group("label"))
+        dem_pct = int(match.group("d"))
+        rep_pct = int(match.group("r"))
+        dem_share = two_party_dem_share(dem_pct, rep_pct)
+
+        if label in {"overall", "all voters", "total", "likely voters"}:
+            result["dem_share_topline"] = dem_share
+            continue
+
+        column = VOTE_LABEL_MAP.get(label)
+        if column is not None:
+            result[column] = dem_share
+
+    return result
+
+
+def parse_quantus_composition_text(text: str) -> dict[str, float]:
+    """Parse the sample-composition block into an ``xt_*`` dict.
+
+    Only rows that appear *after* one of ``_COMPOSITION_HEADERS`` are
+    considered.  This mirrors the Marist NOS pattern: the composition table is
+    a distinct region of the document, and we must not interpret random
+    single-percent rows from the narrative text as composition data.
+
+    Args:
+        text: Raw report text containing both crosstab and composition
+            sections.  The order must be crosstab first, then composition, or
+            an empty dict is returned.
+
+    Returns:
+        Dict mapping ``xt_*`` column names to fractions in [0, 1].  Empty if
+        no composition section is found.
+    """
+    result: dict[str, float] = {}
+
+    in_composition = False
+    for raw_line in text.split("\n"):
+        stripped = raw_line.strip()
+        if any(header in stripped.upper() for header in _COMPOSITION_HEADERS):
+            in_composition = True
+            continue
+        if not in_composition:
+            continue
+
+        match = _SINGLE_PCT_ROW.match(stripped)
+        if not match:
+            continue
+
+        label = _normalize_label(match.group("label"))
+        pct = int(match.group("pct"))
+        column = COMPOSITION_LABEL_MAP.get(label)
+        if column is not None:
+            result[column] = pct / 100.0
+
+    return result
+
+
+def parse_quantus_report_text(text: str) -> dict[str, float]:
+    """Parse a full Quantus report text, merging vote and composition dicts.
+
+    Convenience wrapper that calls both extractors and returns a single dict.
+    Sample-composition keys (``xt_*``) and vote-share keys (``xt_vote_*``) do
+    not collide, so the merge is unambiguous.
+
+    Args:
+        text: Raw report text (from PDF extraction, HTML scrape, or saved
+            fixture).
+
+    Returns:
+        Merged dict with ``xt_vote_*``, ``xt_*``, and (optionally)
+        ``dem_share_topline`` keys.
+    """
+    merged: dict[str, float] = {}
+    vote = parse_quantus_crosstab_text(text)
+    for key, value in vote.items():
+        if value is not None:
+            merged[key] = value
+    composition = parse_quantus_composition_text(text)
+    merged.update(composition)
+    return merged
+
+
+def _extract_text_from_pdf(pdf_path: Path) -> str:
+    """Extract full text from a PDF using pdfplumber.
+
+    Imported lazily so callers that only parse fixture text files do not
+    require pdfplumber to be installed.
+    """
+    import pdfplumber
+
+    with pdfplumber.open(pdf_path) as pdf:
+        pages = [page.extract_text() or "" for page in pdf.pages]
+    return "\n".join(pages)
+
+
+def parse_quantus_report(path: str | Path) -> dict[str, float]:
+    """Parse a Quantus report from a ``.txt`` or ``.pdf`` file on disk.
+
+    Args:
+        path: Path to the Quantus report.  ``.pdf`` files are extracted via
+            pdfplumber; any other extension is read as UTF-8 text.
+
+    Returns:
+        Same dict structure as ``parse_quantus_report_text()``.
+
+    Raises:
+        FileNotFoundError: If ``path`` does not exist.
+    """
+    path = Path(path)
+    if not path.exists():
+        raise FileNotFoundError(f"Quantus report not found: {path}")
+
+    if path.suffix.lower() == ".pdf":
+        text = _extract_text_from_pdf(path)
+    else:
+        text = path.read_text(encoding="utf-8")
+
+    return parse_quantus_report_text(text)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Parse Quantus Insights crosstab reports for demographic vote shares and sample composition."
+    )
+    parser.add_argument("report_path", help="Path to Quantus report (.pdf or .txt)")
+    args = parser.parse_args()
+
+    extracted = parse_quantus_report(args.report_path)
+
+    if not extracted:
+        logger.warning("No crosstab or composition data extracted from %s", args.report_path)
+        sys.exit(1)
+
+    print(f"\nExtracted Quantus crosstab data from {Path(args.report_path).name}:")
+    print("-" * 60)
+    for key, value in sorted(extracted.items()):
+        print(f"  {key}: {value:.4f}")
+    print()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/fixtures/README.md
+++ b/tests/fixtures/README.md
@@ -1,0 +1,19 @@
+# tests/fixtures
+
+Static text fixtures consumed by the crosstab parser tests.  Real PDFs and
+scraped artifacts live under `data/raw/`; this directory holds **synthetic
+extractions** that mirror the format of real pollster output so parser logic
+can be tested without pinning large binary blobs into the test tree.
+
+## quantus_ga_senate_2025_09.txt
+
+Synthetic plain-text crosstab modeled on Quantus Insights' September 9–12,
+2025 Georgia U.S. Senate poll (N=624 likely voters).  The topline numbers
+(Ossoff 40 / Collins 37) match the entry in `data/polls/polls_2026.csv`; the
+demographic breakdowns are plausible but illustrative — their purpose is to
+exercise `scripts/parse_quantus_report.py`, not to make claims about the
+real Quantus crosstab distribution.
+
+Swap in real numbers once a Quantus PDF or HTML crosstab is saved to
+`data/raw/quantus/`.  The parser itself does not need to change — it reads
+text from any source.

--- a/tests/fixtures/quantus_ga_senate_2025_09.txt
+++ b/tests/fixtures/quantus_ga_senate_2025_09.txt
@@ -1,0 +1,40 @@
+QUANTUS INSIGHTS — GEORGIA U.S. SENATE 2026
+Field dates: September 9–12, 2025
+Sample: N=624 likely 2026 Georgia U.S. Senate voters
+Margin of error: ±3.9%
+
+2026 GEORGIA U.S. SENATE — GENERAL ELECTION
+Jon Ossoff (D) vs. Mike Collins (R)
+
+Group                          Ossoff  Collins  Undecided
+Overall                        40%     37%      23%
+Men                            34%     46%      20%
+Women                          45%     29%      26%
+White                          24%     54%      22%
+Black                          86%     6%       8%
+Hispanic                       55%     30%      15%
+18-44                          54%     28%      18%
+45-64                          37%     40%      23%
+65+                            33%     44%      23%
+College graduate               52%     34%      14%
+No college                     33%     40%      27%
+Urban                          55%     27%      18%
+Suburban                       39%     39%      22%
+Rural                          23%     55%      22%
+
+SAMPLE COMPOSITION (weighted %)
+Group                          Weighted %
+Men                            48%
+Women                          52%
+White                          58%
+Black                          31%
+Hispanic                       7%
+Other                          4%
+18-44                          35%
+45-64                          35%
+65 or older                    30%
+College graduate               34%
+No college                     66%
+Urban                          30%
+Suburban                       45%
+Rural                          25%

--- a/tests/test_parse_quantus_report.py
+++ b/tests/test_parse_quantus_report.py
@@ -1,0 +1,276 @@
+"""Tests for the Quantus Insights crosstab parser."""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
+from parse_quantus_report import (  # noqa: E402
+    _normalize_label,
+    parse_quantus_composition_text,
+    parse_quantus_crosstab_text,
+    parse_quantus_report,
+    parse_quantus_report_text,
+    two_party_dem_share,
+)
+
+FIXTURE_PATH = Path(__file__).resolve().parent / "fixtures" / "quantus_ga_senate_2025_09.txt"
+
+
+# ---------------------------------------------------------------------------
+# Label normalization
+# ---------------------------------------------------------------------------
+
+
+class TestLabelNormalization:
+    def test_lowercase(self):
+        assert _normalize_label("COLLEGE") == "college"
+
+    def test_strips_whitespace(self):
+        assert _normalize_label("  Hispanic  ") == "hispanic"
+
+    def test_collapses_internal_whitespace(self):
+        assert _normalize_label("65   or   older") == "65 or older"
+
+    def test_preserves_punctuation(self):
+        # "65+" is a distinct canonical label key — we must not strip the '+'.
+        assert _normalize_label("65+") == "65+"
+
+
+# ---------------------------------------------------------------------------
+# Two-party conversion
+# ---------------------------------------------------------------------------
+
+
+class TestTwoPartyConversion:
+    def test_even_split(self):
+        assert two_party_dem_share(50, 50) == pytest.approx(0.5)
+
+    def test_all_dem(self):
+        assert two_party_dem_share(100, 0) == pytest.approx(1.0)
+
+    def test_all_rep(self):
+        assert two_party_dem_share(0, 100) == pytest.approx(0.0)
+
+    def test_both_zero_returns_none(self):
+        assert two_party_dem_share(0, 0) is None
+
+    def test_quantus_topline(self):
+        # Ossoff 40% vs Collins 37% -> 40/77 = 0.5195
+        assert two_party_dem_share(40, 37) == pytest.approx(0.5195, abs=0.001)
+
+
+# ---------------------------------------------------------------------------
+# Crosstab vote-share parsing
+# ---------------------------------------------------------------------------
+
+
+class TestCrosstabVoteShares:
+    @pytest.fixture(scope="class")
+    def text(self):
+        return FIXTURE_PATH.read_text(encoding="utf-8")
+
+    @pytest.fixture(scope="class")
+    def extracted(self, text):
+        return parse_quantus_crosstab_text(text)
+
+    def test_topline_dem_share(self, extracted):
+        # Overall: Ossoff 40% / Collins 37% -> 40/77 ≈ 0.5195
+        assert extracted["dem_share_topline"] == pytest.approx(0.5195, abs=0.001)
+
+    def test_white_share(self, extracted):
+        # White: 24/78 ≈ 0.3077
+        assert extracted["xt_vote_race_white"] == pytest.approx(0.3077, abs=0.001)
+
+    def test_black_share(self, extracted):
+        # Black: 86/92 ≈ 0.9348
+        assert extracted["xt_vote_race_black"] == pytest.approx(0.9348, abs=0.001)
+
+    def test_hispanic_share(self, extracted):
+        # Hispanic: 55/85 ≈ 0.6471
+        assert extracted["xt_vote_race_hispanic"] == pytest.approx(0.6471, abs=0.001)
+
+    def test_college_share(self, extracted):
+        # College graduate: 52/86 ≈ 0.6047
+        assert extracted["xt_vote_education_college"] == pytest.approx(0.6047, abs=0.001)
+
+    def test_noncollege_share(self, extracted):
+        # No college: 33/73 ≈ 0.4521
+        assert extracted["xt_vote_education_noncollege"] == pytest.approx(0.4521, abs=0.001)
+
+    def test_urban_share(self, extracted):
+        # Urban: 55/82 ≈ 0.6707
+        assert extracted["xt_vote_urbanicity_urban"] == pytest.approx(0.6707, abs=0.001)
+
+    def test_rural_share(self, extracted):
+        # Rural: 23/78 ≈ 0.2949
+        assert extracted["xt_vote_urbanicity_rural"] == pytest.approx(0.2949, abs=0.001)
+
+    def test_at_least_five_xt_vote_values(self, extracted):
+        xt_keys = [k for k in extracted if k.startswith("xt_vote_")]
+        assert len(xt_keys) >= 5
+
+    def test_no_asian_in_fixture(self, extracted):
+        # The GA fixture does not break out Asian — so the column must be
+        # absent, not present-with-None.
+        assert "xt_vote_race_asian" not in extracted
+
+
+class TestCrosstabEdgeCases:
+    def test_empty_text_returns_empty(self):
+        assert parse_quantus_crosstab_text("") == {}
+
+    def test_text_without_percentages(self):
+        assert parse_quantus_crosstab_text("Just some narrative prose.\n") == {}
+
+    def test_partial_demographics(self):
+        text = "Overall 48% 43% 9%\nWhite 32% 55% 13%\n"
+        result = parse_quantus_crosstab_text(text)
+        assert "dem_share_topline" in result
+        assert "xt_vote_race_white" in result
+        assert "xt_vote_race_black" not in result
+
+    def test_alt_labels_latino_and_non_college(self):
+        # Quantus sometimes uses "Latino" and "Non-college" — both must map
+        # to the canonical columns.
+        text = "Latino 60% 30%\nNon-college 35% 55%\n"
+        result = parse_quantus_crosstab_text(text)
+        assert "xt_vote_race_hispanic" in result
+        assert "xt_vote_education_noncollege" in result
+
+    def test_alt_age_label_65_or_older(self):
+        text = "65 or older 40% 50%\n"
+        result = parse_quantus_crosstab_text(text)
+        assert result["xt_vote_age_senior"] == pytest.approx(40 / 90, abs=0.001)
+
+    def test_two_column_rows_still_parse(self):
+        # Quantus occasionally publishes D/R only with no undecided column.
+        text = "White 30% 60%\n"
+        result = parse_quantus_crosstab_text(text)
+        assert result["xt_vote_race_white"] == pytest.approx(30 / 90, abs=0.001)
+
+    def test_four_column_rows_still_parse(self):
+        # Guard against reports that add an explicit "Other" column — we
+        # should still take the first two percentages.
+        text = "Black 85% 8% 4% 3%\n"
+        result = parse_quantus_crosstab_text(text)
+        assert result["xt_vote_race_black"] == pytest.approx(85 / 93, abs=0.001)
+
+    def test_unknown_group_is_ignored(self):
+        text = "LeftHanded Martians 99% 1%\n"
+        assert parse_quantus_crosstab_text(text) == {}
+
+    def test_zero_dem_zero_rep_returns_none(self):
+        text = "White 0% 0%\n"
+        result = parse_quantus_crosstab_text(text)
+        assert result["xt_vote_race_white"] is None
+
+
+# ---------------------------------------------------------------------------
+# Sample-composition parsing
+# ---------------------------------------------------------------------------
+
+
+class TestSampleComposition:
+    @pytest.fixture(scope="class")
+    def text(self):
+        return FIXTURE_PATH.read_text(encoding="utf-8")
+
+    @pytest.fixture(scope="class")
+    def composition(self, text):
+        return parse_quantus_composition_text(text)
+
+    def test_white(self, composition):
+        assert composition["xt_race_white"] == pytest.approx(0.58)
+
+    def test_black(self, composition):
+        assert composition["xt_race_black"] == pytest.approx(0.31)
+
+    def test_hispanic(self, composition):
+        assert composition["xt_race_hispanic"] == pytest.approx(0.07)
+
+    def test_college(self, composition):
+        assert composition["xt_education_college"] == pytest.approx(0.34)
+
+    def test_noncollege(self, composition):
+        assert composition["xt_education_noncollege"] == pytest.approx(0.66)
+
+    def test_senior(self, composition):
+        # "65 or older" row -> xt_age_senior
+        assert composition["xt_age_senior"] == pytest.approx(0.30)
+
+    def test_urban(self, composition):
+        assert composition["xt_urbanicity_urban"] == pytest.approx(0.30)
+
+    def test_rural(self, composition):
+        assert composition["xt_urbanicity_rural"] == pytest.approx(0.25)
+
+    def test_all_values_are_fractions(self, composition):
+        for value in composition.values():
+            assert 0.0 <= value <= 1.0
+
+    def test_returns_no_vote_columns(self, composition):
+        # Composition keys must never include the ``_vote_`` infix.
+        for key in composition:
+            assert "_vote_" not in key
+
+
+class TestCompositionEdgeCases:
+    def test_empty_text_returns_empty(self):
+        assert parse_quantus_composition_text("") == {}
+
+    def test_text_without_header_returns_empty(self):
+        # Even with recognizable "White 58%" lines, we should refuse to parse
+        # them as composition unless preceded by a composition section header.
+        text = "White 58%\nBlack 31%\n"
+        assert parse_quantus_composition_text(text) == {}
+
+    def test_header_variants(self):
+        for header in (
+            "SAMPLE COMPOSITION",
+            "Sample composition (weighted)",
+            "NATURE OF THE SAMPLE",
+            "Weighted Sample",
+        ):
+            text = f"{header}\nWhite 58%\nBlack 31%\n"
+            result = parse_quantus_composition_text(text)
+            assert result.get("xt_race_white") == pytest.approx(0.58)
+            assert result.get("xt_race_black") == pytest.approx(0.31)
+
+    def test_unknown_group_is_ignored(self):
+        text = "SAMPLE COMPOSITION\nMartians 4%\n"
+        assert parse_quantus_composition_text(text) == {}
+
+
+# ---------------------------------------------------------------------------
+# Full-report parsing & file I/O
+# ---------------------------------------------------------------------------
+
+
+class TestFullReport:
+    def test_merges_vote_and_composition_keys(self):
+        text = FIXTURE_PATH.read_text(encoding="utf-8")
+        merged = parse_quantus_report_text(text)
+        # Both families of keys must appear in the merged output.
+        assert any(k.startswith("xt_vote_") for k in merged)
+        assert any(k.startswith("xt_") and not k.startswith("xt_vote_") for k in merged)
+        # Topline too.
+        assert "dem_share_topline" in merged
+
+    def test_no_collisions_between_vote_and_composition(self):
+        text = FIXTURE_PATH.read_text(encoding="utf-8")
+        vote = parse_quantus_crosstab_text(text)
+        comp = parse_quantus_composition_text(text)
+        overlap = set(vote) & set(comp)
+        assert overlap == set(), f"Unexpected overlap: {overlap}"
+
+    def test_parse_report_from_txt_file(self):
+        merged = parse_quantus_report(FIXTURE_PATH)
+        assert merged["dem_share_topline"] == pytest.approx(0.5195, abs=0.001)
+        assert merged["xt_race_white"] == pytest.approx(0.58)
+
+    def test_parse_report_missing_file_raises(self, tmp_path):
+        missing = tmp_path / "does_not_exist.txt"
+        with pytest.raises(FileNotFoundError):
+            parse_quantus_report(missing)


### PR DESCRIPTION
## Summary
- New text-in, dict-out parser for Quantus Insights PDF/Substack crosstab reports
- Extracts `xt_vote_*` (per-group vote shares) and `xt_*` (sample composition)
- Canonical column names match Emerson/Marist parsers — no downstream changes needed
- GA Senate 2025-09 fixture for offline testing

## Test plan
- [x] 46 unit tests pass
- [ ] Wire into poll ingestion pipeline for live Quantus reports

🤖 Generated with [Claude Code](https://claude.com/claude-code)