### PR TITLE
fix(polls): preserve xt_* crosstab + methodology on re-scrape (#94)

### DIFF
--- a/data/polls/polls_2026.csv
+++ b/data/polls/polls_2026.csv
@@ -1,227 +1,227 @@
-race,geography,geo_level,dem_share,n_sample,date,pollster,notes
-2026 AL Governor,AL,state,0.3908,605.0,2025-11-13,Cygnal,D=34.0% R=53.0%; LV; src=wikipedia
-2026 AZ Governor,AZ,state,0.5057,850.0,2025-11-10,Emerson College,D=44.0% R=43.0%; RV; src=rcp
-2026 AZ Governor,AZ,state,0.5316,1023.0,2026-02-26,Noble Predictive Insights,D=42.0% R=37.0%; RV; src=rcp
-2026 FL Governor,FL,state,0.4607,600.0,2024-10-28,Cygnal,D=41.0% R=48.0%; LV; src=wikipedia
-2026 FL Governor,FL,state,0.4722,1200.0,2025-05-07,Targoz Market Research,D=34.0% R=38.0%; RV; src=wikipedia
-2026 FL Governor,FL,state,0.4559,600.0,2025-06-10,Victory Insights,D=31.0% R=37.0%; LV; src=wikipedia
-2026 FL Governor,FL,state,0.4556,800.0,2025-08-27,AIF Center (R),D=41.0% R=49.0%; LV; src=wikipedia
-2026 FL Governor,FL,state,0.427,1000.0,2025-08-27,Cygnal,D=38.0% R=51.0%; LV; src=wikipedia
-2026 FL Governor,FL,state,0.5062,631.0,2025-09-09,Bendixen & Amandi International,D=41.0% R=40.0%; LV; src=wikipedia
-2026 FL Governor,FL,state,0.4706,1118.0,2025-09-18,Targoz Market Research,D=32.0% R=36.0%; RV; src=wikipedia
-2026 FL Governor,FL,state,0.4231,728.0,2025-10-25,University of North Florida,D=33.0% R=45.0%; LV; src=wikipedia
-2026 FL Governor,FL,state,0.4337,728.0,2025-10-28,University of North Florida,D=36.0% R=47.0%; LV; src=270towin
-2026 FL Governor,FL,state,0.4675,1129.0,2026-02-16,Targoz Market Research,D=36.0% R=41.0%; LV; src=wikipedia
-2026 FL Governor,FL,state,0.4557,786.0,2026-03-02,University of North Florida,D=36.0% R=43.0%; LV; src=rcp
-2026 FL Governor,FL,state,0.4557,786.0,2026-03-04,University of North Florida,D=36.0% R=43.0%; LV; src=270towin
-2026 FL Governor,FL,state,0.4444,1125.0,2026-03-31,Emerson College,D=36.0% R=45.0%; LV; src=rcp
-2026 FL Governor,FL,state,0.4875,1125.0,2026-04-02,Emerson College,D=39.0% R=41.0%; LV; src=270towin
-2026 FL Governor,FL,state,0.5,1834.0,2026-04-03,MDW (D),D=41.0% R=41.0%; LV; src=wikipedia
-2026 FL Governor,FL,state,0.4762,795.0,2026-04-06,Keystone Analytics,D=40.0% R=44.0%; LV; src=wikipedia
-2026 FL Governor,FL,state,0.5,1834.0,2026-04-13,Edge / MDW Communications,D=41.0% R=41.0%; LV; src=270towin
-2026 FL Senate,FL,state,0.4568,800.0,2025-10-03,Tyson Group,D=37.0% R=44.0%; LV; src=wikipedia
-2026 FL Senate,FL,state,0.4368,728.0,2025-10-25,University of North Florida,D=38.0% R=49.0%; LV; src=wikipedia
-2026 FL Senate,FL,state,0.4524,786.0,2026-03-02,University of North Florida,D=38.0% R=46.0%; LV; src=wikipedia
-2026 FL Senate,FL,state,0.4524,786.0,2026-03-04,University of North Florida,D=38.0% R=46.0%; LV; src=270towin
-2026 FL Senate,FL,state,0.4337,1125.0,2026-03-31,Emerson College,D=36.0% R=47.0%; LV; src=wikipedia
-2026 FL Senate,FL,state,0.4337,1125.0,2026-04-02,Emerson College,D=36.0% R=47.0%; LV; src=270towin
-2026 FL Senate,FL,state,0.4941,1834.0,2026-04-03,MDW (D),D=42.0% R=43.0%; LV; src=wikipedia
-2026 FL Senate,FL,state,0.4941,1834.0,2026-04-13,Edge / MDW Communications,D=42.0% R=43.0%; LV; src=270towin
-2026 GA Senate,GA,state,0.5844,500.0,2025-01-15,WPA Intelligence,D=45.0% R=32.0%; LV; src=wikipedia
-2026 GA Senate,GA,state,0.5465,600.0,2025-01-31,Tyson Group,D=47.0% R=39.0%; LV; src=wikipedia
-2026 GA Senate,GA,state,0.5465,600.0,2025-02-11,Tyson Group,D=47.0% R=39.0%; LV; src=270towin
-2026 GA Senate,GA,state,0.4839,800.0,2025-02-13,Quantus Insights,D=45.0% R=48.0%; RV; src=wikipedia
-2026 GA Senate,GA,state,0.5,600.0,2025-03-10,Cygnal,D=44.0% R=44.0%; LV; src=wikipedia
-2026 GA Senate,GA,state,0.5517,1000.0,2025-04-24,Atlanta Journal-Constitution,D=48.0% R=39.0%; RV; src=wikipedia
-2026 GA Senate,GA,state,0.5275,1426.0,2025-04-27,Trafalgar Group,D=48.0% R=43.0%; LV; src=wikipedia
-2026 GA Senate,GA,state,0.5227,800.0,2025-05-17,Cygnal,D=46.0% R=42.0%; LV; src=rcp
-2026 GA Senate,GA,state,0.5169,800.0,2025-05-22,Cygnal,D=46.0% R=43.0%; LV; src=270towin
-2026 GA Senate,GA,state,0.5385,610.0,2025-06-18,Cygnal,D=49.0% R=42.0%; LV; src=wikipedia
-2026 GA Senate,GA,state,0.5238,2956.0,2025-08-01,TIPP Insights,D=44.0% R=40.0%; RV; src=rcp
-2026 GA Senate,GA,state,0.5195,624.0,2025-09-12,Quantus Insights,D=40.0% R=37.0%; RV; src=rcp
-2026 GA Senate,GA,state,0.5455,624.0,2025-09-15,Quantus Insights,D=42.0% R=35.0%; LV; src=270towin
-2026 GA Senate,GA,state,0.5165,1000.0,2026-03-02,Emerson College,D=47.0% R=44.0%; LV; src=rcp
-2026 GA Senate,GA,state,0.5444,1000.0,2026-03-05,Emerson College,D=49.0% R=41.0%; LV; src=270towin
-2026 Generic Ballot,US,national,0.5464,1392.0,2026-03-04,NPR,D=53.0% R=44.0%; RV; src=rcp
-2026 Generic Ballot,US,national,0.5238,1147.0,2026-03-16,Yahoo News,D=44.0% R=40.0%; RV; src=rcp
-2026 Generic Ballot,US,national,0.5385,1000.0,2026-03-17,Emerson College,D=49.0% R=42.0%; LV; src=rcp
-2026 Generic Ballot,US,national,0.5128,985.0,2026-03-23,Reuters,D=40.0% R=38.0%; RV; src=rcp
-2026 Generic Ballot,US,national,0.5604,1191.0,2026-03-23,Quinnipiac University,D=51.0% R=40.0%; RV; src=rcp
-2026 Generic Ballot,US,national,0.5172,2222.0,2026-03-23,Rasmussen Reports,D=45.0% R=42.0%; LV; src=rcp
-2026 Generic Ballot,US,national,0.5455,3003.0,2026-03-24,Big Data Poll,D=48.0% R=40.0%; LV; src=rcp
-2026 Generic Ballot,US,national,0.52,,2026-03-26,Harvard-Harris,D=52.0% R=48.0%; LV; src=rcp
-2026 Generic Ballot,US,national,0.5341,1472.0,2026-03-26,Quantus Insights,D=47.0% R=41.0%; LV; src=rcp
-2026 Generic Ballot,US,national,0.5333,952.0,2026-03-30,CNN,D=48.0% R=42.0%; RV; src=rcp
-2026 Generic Ballot,US,national,0.5326,1500.0,2026-04-03,Cygnal,D=49.0% R=43.0%; LV; src=rcp
-2026 Generic Ballot,US,national,0.5172,2200.0,2026-04-05,Morning Consult,D=45.0% R=42.0%; RV; src=rcp
-2026 Generic Ballot,US,national,0.5116,1560.0,2026-04-06,Economist/YouGov,D=44.0% R=42.0%; RV; src=rcp
-2026 Generic Ballot,US,national,0.5269,2000.0,2026-04-09,RMG Research,D=49.0% R=44.0%; RV; src=rcp
-2026 Generic Ballot,US,national,0.5294,1573.0,2026-04-13,Economist/YouGov,D=45.0% R=40.0%; RV; src=rcp
-2026 Generic Ballot,US,national,0.5172,2203.0,2026-04-20,Morning Consult,D=45.0% R=42.0%; RV; src=rcp
-2026 IA Senate,IA,state,0.4824,1108.0,2026-01-11,Change Research (D),D=41.0% R=44.0%; LV; src=wikipedia
-2026 IA Senate,IA,state,0.4778,1200.0,2026-03-16,GQR (D),D=43.0% R=47.0%; LV; src=wikipedia
-2026 MA Senate,MA,state,0.6353,500.0,2025-11-23,Boston Globe/Suffolk,D=54.0% R=31.0%; RV; src=rcp
-2026 MA Senate,MA,state,0.6747,620.0,2026-02-16,UNH,D=56.0% R=27.0%; LV; src=rcp
-2026 ME Senate,ME,state,0.5316,501.0,2025-10-10,Zenith Research (D),D=42.0% R=37.0%; LV; src=wikipedia
-2026 ME Senate,ME,state,0.4773,783.0,2025-10-29,Maine People's Resource Center,D=42.0% R=46.0%; LV; src=wikipedia
-2026 ME Senate,ME,state,0.5444,600.0,2025-11-11,Cygnal,D=49.0% R=41.0%; LV; src=wikipedia
-2026 ME Senate,ME,state,0.4773,783.0,2025-11-12,Maine People's Resource Center,D=42.0% R=46.0%; RV; src=270towin
-2026 ME Senate,ME,state,0.5,820.0,2025-12-07,Pan Atlantic Research,D=43.0% R=43.0%; LV; src=wikipedia
-2026 ME Senate,ME,state,0.5,820.0,2025-12-10,Pan Atlantic Research,D=43.0% R=43.0%; LV; src=270towin
-2026 ME Senate,ME,state,0.49,900.0,2025-12-16,Workbench Strategy (D),D=49.0% R=51.0%; LV; src=wikipedia
-2026 ME Senate,ME,state,0.4944,800.0,2026-01-24,Fabrizio Lee & Associates,D=44.0% R=45.0%; LV; src=wikipedia
-2026 ME Senate,ME,state,0.5632,1120.0,2026-02-16,UNH,D=49.0% R=38.0%; LV; src=rcp
-2026 ME Senate,ME,state,0.5062,1105.0,2026-02-16,University of New Hampshire,D=41.0% R=40.0%; LV; src=wikipedia
-2026 ME Senate,ME,state,0.5062,1120.0,2026-02-24,Univ. of New Hampshire,D=41.0% R=40.0%; LV; src=270towin
-2026 ME Senate,ME,state,0.5238,810.0,2026-03-02,Pan Atlantic,D=44.0% R=40.0%; LV; src=rcp
-2026 ME Senate,ME,state,0.5,810.0,2026-03-02,Pan Atlantic Research,D=44.0% R=44.0%; LV; src=wikipedia
-2026 ME Senate,ME,state,0.5,810.0,2026-03-04,Pan Atlantic Research,D=44.0% R=44.0%; LV; src=270towin
-2026 ME Senate,ME,state,0.5385,800.0,2026-03-05,Quantus Insights,D=49.0% R=42.0%; LV; src=rcp
-2026 ME Senate,ME,state,0.5,600.0,2026-03-08,OnMessage Public Strategies (R),D=42.0% R=42.0%; LV; src=wikipedia
-2026 ME Senate,ME,state,0.4886,800.0,2026-03-09,Quantus Insights,D=43.0% R=45.0%; LV; src=270towin
-2026 ME Senate,ME,state,0.5,600.0,2026-03-10,OnMessage,D=42.0% R=42.0%; LV; src=270towin
-2026 ME Senate,ME,state,0.5393,1075.0,2026-03-23,Emerson College,D=48.0% R=41.0%; LV; src=rcp
-2026 ME Senate,ME,state,0.5169,1075.0,2026-03-26,Emerson College,D=46.0% R=43.0%; LV; src=270towin
-2026 ME Senate,ME,state,0.5517,1167.0,2026-03-31,MPRC,D=48.0% R=39.0%; LV; src=rcp
-2026 ME Senate,ME,state,0.4828,1167.0,2026-03-31,Maine People's Resource Center (D),D=42.0% R=45.0%; LV; src=wikipedia
-2026 ME Senate,ME,state,0.4828,1167.0,2026-04-07,Maine People's Resource Center,D=42.0% R=45.0%; LV; src=270towin
-2026 ME Senate,ME,state,0.4977,,,Decision Desk HQ,D=43.4% R=43.8%; src=wikipedia
-2026 MI Governor,MI,state,0.5833,600.0,2025-02-08,Target Insyght,D=42.0% R=30.0%; src=wikipedia
-2026 MI Governor,MI,state,0.5,600.0,2025-02-08,EPIC-MRA,D=31.0% R=31.0%; LV; src=wikipedia
-2026 MI Governor,MI,state,0.5833,600.0,2025-03-08,Target Insyght,D=42.0% R=30.0%; RV; src=270towin
-2026 MI Governor,MI,state,0.5211,688.0,2025-03-13,Mitchell Research,D=37.0% R=34.0%; LV; src=wikipedia
-2026 MI Governor,MI,state,0.5211,688.0,2025-03-18,Mitchell Research,D=37.0% R=34.0%; LV; src=270towin
-2026 MI Governor,MI,state,0.5072,600.0,2025-05-28,Glengariff Group,D=35.0% R=34.0%; RV; src=270towin
-2026 MI Governor,MI,state,0.4658,252.0,2025-10-25,Rosetta Stone,D=34.0% R=39.0%; LV; src=rcp
-2026 MI Governor,MI,state,0.4658,637.0,2025-10-25,Rosetta Stone Communications (R),D=34.0% R=39.0%; LV; src=wikipedia
-2026 MI Governor,MI,state,0.4658,637.0,2025-11-06,Rosetta Stone,D=34.0% R=39.0%; LV; src=270towin
-2026 MI Governor,MI,state,0.4925,600.0,2025-11-11,EPIC-MRA,D=33.0% R=34.0%; RV; src=rcp
-2026 MI Governor,MI,state,0.4925,600.0,2025-11-14,EPIC-MRA,D=33.0% R=34.0%; LV; src=270towin
-2026 MI Governor,MI,state,0.4559,616.0,2025-11-21,Mitchell Research,D=31.0% R=37.0%; LV; src=rcp
-2026 MI Governor,MI,state,0.4559,616.0,2025-12-02,Mitchell Research,D=31.0% R=37.0%; LV; src=270towin
-2026 MI Governor,MI,state,0.4848,600.0,2026-01-06,Detroit News,D=32.0% R=34.0%; LV; src=rcp
-2026 MI Governor,MI,state,0.4745,,2026-01-06,Real Clear Politics,D=32.5% R=36.0%; src=wikipedia
-2026 MI Governor,MI,state,0.4848,600.0,2026-01-06,Glengariff Group,D=32.0% R=34.0%; LV; src=wikipedia
-2026 MI Governor,MI,state,0.4848,600.0,2026-01-13,Glengariff Group,D=32.0% R=34.0%; LV; src=270towin
-2026 MI Governor,MI,state,0.4912,,2026-02-02,Glengariff Group,D=28.0% R=29.0%; LV; src=wikipedia
-2026 MI Governor,MI,state,0.52,800.0,2026-02-16,Impact Research (D),D=39.0% R=36.0%; LV; src=wikipedia
-2026 MI Governor,MI,state,0.587,1000.0,2026-03-24,Michigan State University/YouGov,D=27.0% R=19.0%; src=wikipedia
-2026 MI Governor,MI,state,0.5263,800.0,2026-03-29,Impact Research (D),D=40.0% R=36.0%; LV; src=wikipedia
-2026 MI Governor,MI,state,0.566,1000.0,2026-04-20,Michigan State Univ.,D=30.0% R=23.0%; src=270towin
-2026 MI Governor,MI,state,0.5085,600.0,,Schoen Cooperman Research (D),D=30.0% R=29.0%; LV; src=wikipedia
-2026 MI Governor,MI,state,0.5072,600.0,,Glengariff Group,D=35.0% R=34.0%; RV; src=wikipedia
-2026 MI Governor,MI,state,0.4697,600.0,,Plymouth Union Public (R),D=31.0% R=35.0%; LV; src=wikipedia
-2026 MI Senate,MI,state,0.4659,600.0,2025-02-08,EPIC-MRA,D=41.0% R=47.0%; src=wikipedia
-2026 MI Senate,MI,state,0.4605,600.0,2025-03-06,Target Insyght,D=35.0% R=41.0%; src=wikipedia
-2026 MI Senate,MI,state,0.5056,688.0,2025-03-13,Mitchell Research,D=45.0% R=44.0%; LV; src=wikipedia
-2026 MI Senate,MI,state,0.5056,600.0,2025-05-08,Glengariff Group,D=45.0% R=44.0%; RV; src=wikipedia
-2026 MI Senate,MI,state,0.5109,700.0,2025-06-16,Normington Petts (D),D=47.0% R=45.0%; LV; src=wikipedia
-2026 MI Senate,MI,state,0.4598,637.0,2025-10-25,Rosetta Stone Communications (R),D=40.0% R=47.0%; LV; src=wikipedia
-2026 MI Senate,MI,state,0.5116,600.0,2025-11-11,EPIC-MRA,D=44.0% R=42.0%; RV; src=wikipedia
-2026 MI Senate,MI,state,0.4878,616.0,2025-11-21,Mitchell Research & Communications,D=40.0% R=42.0%; LV; src=wikipedia
-2026 MI Senate,MI,state,0.5281,600.0,2026-01-06,Glengariff Group,D=47.0% R=42.0%; LV; src=wikipedia
-2026 MI Senate,MI,state,0.5281,1000.0,2026-01-25,Emerson College,D=47.0% R=42.0%; LV; src=wikipedia
-2026 MN Governor,MN,state,0.5904,575.0,2026-01-30,SurveyUSA,D=49.0% R=34.0%; RV; src=rcp
-2026 MN Governor,MN,state,0.573,1000.0,2026-02-08,Emerson College,D=51.0% R=38.0%; RV; src=rcp
-2026 MN Senate,MN,state,0.5213,604.0,2025-07-11,Impact Research (D),D=49.0% R=45.0%; LV; src=wikipedia
-2026 MN Senate,MN,state,0.5402,1000.0,2026-02-08,Emerson College,D=47.0% R=40.0%; LV; src=wikipedia
-2026 MN Senate,MN,state,0.5402,1000.0,2026-02-11,Emerson College,D=47.0% R=40.0%; LV; src=270towin
-2026 NC Senate,NC,state,0.5056,800.0,2024-11-29,Victory Insights,D=45.0% R=44.0%; LV; src=wikipedia
-2026 NC Senate,NC,state,0.5111,867.0,2025-04-04,Change Research (D),D=46.0% R=44.0%; LV; src=wikipedia
-2026 NC Senate,NC,state,0.5341,1000.0,2025-07-30,Emerson College,D=47.0% R=41.0%; RV; src=wikipedia
-2026 NC Senate,NC,state,0.5181,600.0,2025-07-30,Victory Insights,D=43.0% R=40.0%; LV; src=wikipedia
-2026 NC Senate,NC,state,0.5181,600.0,2025-07-31,Victory Insights,D=43.0% R=40.0%; LV; src=270towin
-2026 NC Senate,NC,state,0.5341,1000.0,2025-08-01,Emerson College,D=47.0% R=41.0%; RV; src=270towin
-2026 NC Senate,NC,state,0.5393,855.0,2025-09-08,Change Research (D),D=48.0% R=41.0%; LV; src=wikipedia
-2026 NC Senate,NC,state,0.5281,1105.0,2026-01-07,Change Research (D),D=47.0% R=42.0%; LV; src=wikipedia
-2026 NC Senate,NC,state,0.6667,1512.0,2026-01-15,TIPP Insights (R),D=48.0% R=24.0%; RV; src=wikipedia
-2026 NC Senate,NC,state,0.5556,1069.0,2026-02-04,Change Research,D=50.0% R=40.0%; LV; src=rcp
-2026 NC Senate,NC,state,0.5556,1069.0,2026-02-04,Change Research (D),D=50.0% R=40.0%; RV; src=wikipedia
-2026 NC Senate,NC,state,0.5556,1069.0,2026-02-20,Change Research,D=50.0% R=40.0%; RV; src=270towin
-2026 NC Senate,NC,state,0.6098,800.0,2026-03-09,Nexus Strategies/ Strategic Partners Solutions,D=50.0% R=32.0%; RV; src=wikipedia
-2026 NC Senate,NC,state,0.5165,556.0,2026-03-14,Public Policy Polling,D=47.0% R=44.0%; RV; src=rcp
-2026 NC Senate,NC,state,0.5854,1000.0,2026-03-18,Catawba College/YouGov,D=48.0% R=34.0%; LV; src=wikipedia
-2026 NC Senate,NC,state,0.5444,600.0,2026-03-23,Carolina Journal/Harper,D=49.0% R=41.0%; LV; src=rcp
-2026 NC Senate,NC,state,0.6098,800.0,2026-03-27,Nexus/Strategic Partners Solutions,D=50.0% R=32.0%; LV; src=270towin
-2026 NC Senate,NC,state,0.5854,871.0,2026-03-31,Catawba College,D=48.0% R=34.0%; LV; src=270towin
-2026 NC Senate,NC,state,0.5269,987.0,2026-04-01,Quantus Insights,D=49.0% R=44.0%; LV; src=rcp
-2026 NC Senate,NC,state,0.5269,987.0,2026-04-02,Quantus Insights,D=49.0% R=44.0%; LV; src=270towin
-2026 NC Senate,NC,state,0.5435,703.0,2026-04-06,High Point/YouGov,D=50.0% R=42.0%; LV; src=rcp
-2026 NC Senate,NC,state,0.5435,703.0,2026-04-06,High Point University/YouGov,D=50.0% R=42.0%; LV; src=wikipedia
-2026 NC Senate,NC,state,0.5435,703.0,2026-04-17,High Point Univ.,D=50.0% R=42.0%; LV; src=270towin
-2026 NH Governor,NH,state,0.4382,2053.0,2026-01-19,UNH,D=39.0% R=50.0%; LV; src=rcp
-2026 NH Governor,NH,state,0.4079,1491.0,2026-03-18,St. Anselm,D=31.0% R=45.0%; RV; src=rcp
-2026 NH Senate,NH,state,0.46,626.0,2025-03-01,Praecones Analytica,D=46.0% R=54.0%; RV; src=wikipedia
-2026 NH Senate,NH,state,0.4536,650.0,2025-03-19,Quantus Insights,D=44.0% R=53.0%; RV; src=wikipedia
-2026 NH Senate,NH,state,0.5647,1776.0,2025-08-27,Saint Anselm College,D=48.0% R=37.0%; RV; src=wikipedia
-2026 NH Senate,NH,state,0.5647,1776.0,2025-09-05,Saint Anselm College,D=48.0% R=37.0%; RV; src=270towin
-2026 NH Senate,NH,state,0.5556,904.0,2025-09-12,co/efficient (R),D=50.0% R=40.0%; LV; src=wikipedia
-2026 NH Senate,NH,state,0.5169,904.0,2025-09-15,co/efficient,D=46.0% R=43.0%; LV; src=270towin
-2026 NH Senate,NH,state,0.5843,1235.0,2025-09-23,University of New Hampshire,D=52.0% R=37.0%; LV; src=wikipedia
-2026 NH Senate,NH,state,0.5326,1235.0,2025-09-29,Univ. of New Hampshire,D=49.0% R=43.0%; LV; src=270towin
-2026 NH Senate,NH,state,0.5568,1034.0,2025-10-13,co/efficient (R),D=49.0% R=39.0%; LV; src=wikipedia
-2026 NH Senate,NH,state,0.5172,1034.0,2025-10-15,co/efficient,D=45.0% R=42.0%; LV; src=270towin
-2026 NH Senate,NH,state,0.55,2212.0,2025-11-19,Saint Anselm College,D=44.0% R=36.0%; RV; src=wikipedia
-2026 NH Senate,NH,state,0.5176,2212.0,2025-11-24,Univ. of New Hampshire,D=44.0% R=41.0%; RV; src=270towin
-2026 NH Senate,NH,state,0.6216,603.0,2025-12-28,NHJournal/Praecones Analytica,D=46.0% R=28.0%; RV; src=wikipedia
-2026 NH Senate,NH,state,0.5385,603.0,2026-01-04,NH Journal,D=42.0% R=36.0%; RV; src=270towin
-2026 NH Senate,NH,state,0.5263,2053.0,2026-01-19,UNH,D=50.0% R=45.0%; LV; src=rcp
-2026 NH Senate,NH,state,0.5532,2053.0,2026-01-19,University of New Hampshire,D=52.0% R=42.0%; LV; src=wikipedia
-2026 NH Senate,NH,state,0.5263,2053.0,2026-01-21,Univ. of New Hampshire,D=50.0% R=45.0%; LV; src=270towin
-2026 NH Senate,NH,state,0.5233,563.0,2026-01-29,yes. every kid.,D=45.0% R=41.0%; LV; src=wikipedia
-2026 NH Senate,NH,state,0.5169,1491.0,2026-03-18,St. Anselm,D=46.0% R=43.0%; RV; src=rcp
-2026 NH Senate,NH,state,0.5529,1491.0,2026-03-18,Saint Anselm College,D=47.0% R=38.0%; RV; src=wikipedia
-2026 NH Senate,NH,state,0.5169,1491.0,2026-03-23,Saint Anselm College,D=46.0% R=43.0%; RV; src=270towin
-2026 NH Senate,NH,state,0.5056,1100.0,2026-03-23,Emerson College,D=45.0% R=44.0%; LV; src=rcp
-2026 NH Senate,NH,state,0.5056,1100.0,2026-03-26,Emerson College,D=45.0% R=44.0%; LV; src=270towin
-2026 NV Governor,NV,state,0.5,800.0,2025-11-18,Emerson College,D=41.0% R=41.0%; RV; src=rcp
-2026 NV Governor,NV,state,0.4935,845.0,2026-03-13,Noble Predictive Insights,D=38.0% R=39.0%; RV; src=rcp
-2026 NY Governor,NY,state,0.6024,1442.0,2026-02-19,Marist College,D=50.0% R=33.0%; RV; src=rcp
-2026 NY Governor,NY,state,0.5802,804.0,2026-03-26,Siena College,D=47.0% R=34.0%; RV; src=rcp
-2026 OH Governor,OH,state,0.4737,800.0,2025-04-24,Bowling Green State University/YouGov,D=45.0% R=50.0%; RV; src=wikipedia
-2026 OH Governor,OH,state,0.4737,800.0,2025-04-29,Bowling Green Univ.,D=45.0% R=50.0%; RV; src=270towin
-2026 OH Governor,OH,state,0.4946,800.0,2025-07-28,Impact Research (D),D=46.0% R=47.0%; LV; src=wikipedia
-2026 OH Governor,OH,state,0.4432,1000.0,2025-08-19,Emerson College,D=39.0% R=49.0%; RV; src=wikipedia
-2026 OH Governor,OH,state,0.4432,1000.0,2025-08-22,Emerson College,D=39.0% R=49.0%; LV; src=270towin
-2026 OH Governor,OH,state,0.5055,800.0,2025-09-22,Hart Research (D),D=46.0% R=45.0%; LV; src=wikipedia
-2026 OH Governor,OH,state,0.4845,800.0,2025-10-14,YouGov,D=47.0% R=50.0%; RV; src=rcp
-2026 OH Governor,OH,state,0.4845,800.0,2025-10-14,Bowling Green State University/YouGov,D=47.0% R=50.0%; RV; src=wikipedia
-2026 OH Governor,OH,state,0.4845,800.0,2025-10-17,Bowling Green Univ.,D=47.0% R=50.0%; RV; src=270towin
-2026 OH Governor,OH,state,0.5055,850.0,2025-12-08,Emerson College,D=46.0% R=45.0%; RV; src=rcp
-2026 OH Governor,OH,state,0.4886,603.0,2025-12-08,Data Targeting (R),D=43.0% R=45.0%; LV; src=wikipedia
-2026 OH Governor,OH,state,0.5055,850.0,2025-12-11,Emerson College,D=46.0% R=45.0%; RV; src=270towin
-2026 OH Governor,OH,state,0.5521,1343.0,2026-02-22,EMC Research (D),D=53.0% R=43.0%; LV; src=wikipedia
-2026 OH Governor,OH,state,0.5521,1343.0,2026-03-10,EMC Research,D=53.0% R=43.0%; LV; src=270towin
-2026 OH Governor,OH,state,0.5055,809.0,2026-03-14,Quantus Insights,D=46.0% R=45.0%; LV; src=rcp
-2026 OH Governor,OH,state,0.5055,809.0,2026-03-16,Quantus Insights,D=46.0% R=45.0%; LV; src=270towin
-2026 OH Governor,OH,state,0.4947,1000.0,2026-04-14,YouGov,D=47.0% R=48.0%; RV; src=rcp
-2026 OH Governor,OH,state,0.4947,1000.0,2026-04-14,Bowling Green State University/YouGov,D=47.0% R=48.0%; RV; src=wikipedia
-2026 OH Governor,OH,state,0.4947,1000.0,2026-04-20,Bowling Green Univ.,D=47.0% R=48.0%; RV; src=270towin
-2026 OH Governor,OH,state,0.4984,,,Decision Desk HQ,D=45.4% R=45.7%; src=wikipedia
-2026 OH Senate,OH,state,0.5052,800.0,2025-10-14,YouGov,D=49.0% R=48.0%; RV; src=rcp
-2026 OH Senate,OH,state,0.4842,850.0,2025-12-08,Emerson College,D=46.0% R=49.0%; RV; src=rcp
-2026 OH Senate,OH,state,0.4889,784.0,2026-03-14,Quantus Insights,D=44.0% R=46.0%; LV; src=rcp
-2026 OH Senate,OH,state,0.4845,1000.0,2026-04-14,YouGov,D=47.0% R=50.0%; RV; src=rcp
-2026 PA Governor,PA,state,0.5851,1579.0,2025-09-29,Quinnipiac University,D=55.0% R=39.0%; RV; src=wikipedia
-2026 PA Governor,PA,state,0.5895,1579.0,2025-10-01,Quinnipiac University,D=56.0% R=39.0%; RV; src=270towin
-2026 PA Governor,PA,state,0.5978,836.0,2026-02-23,Quinnipiac University,D=55.0% R=37.0%; RV; src=rcp
-2026 PA Governor,PA,state,0.5978,836.0,2026-02-25,Quinnipiac University,D=55.0% R=37.0%; RV; src=270towin
-2026 PA Governor,PA,state,0.6316,834.0,2026-03-01,Franklin &amp; Marshall,D=48.0% R=28.0%; RV; src=rcp
-2026 PA Governor,PA,state,0.6316,834.0,2026-03-01,Franklin & Marshall College,D=48.0% R=28.0%; RV; src=wikipedia
-2026 PA Governor,PA,state,0.6316,834.0,2026-03-05,Franklin & Marshall,D=48.0% R=28.0%; RV; src=270towin
-2026 PA Governor,PA,state,0.617,700.0,2026-03-29,Susquehanna,D=58.0% R=36.0%; LV; src=rcp
-2026 TX Governor,TX,state,0.4674,843.0,2025-08-29,Texas Public Opinion Research,D=43.0% R=49.0%; RV; src=wikipedia
-2026 TX Governor,TX,state,0.4565,1165.0,2026-01-12,Emerson College,D=42.0% R=50.0%; LV; src=rcp
-2026 TX Governor,TX,state,0.4565,1165.0,2026-01-15,Emerson College,D=42.0% R=50.0%; LV; src=270towin
-2026 TX Governor,TX,state,0.4615,1502.0,2026-01-31,University of Houston,D=42.0% R=49.0%; LV; src=rcp
-2026 TX Governor,TX,state,0.4615,1502.0,2026-01-31,University of Houston/YouGov,D=42.0% R=49.0%; LV; src=wikipedia
-2026 TX Governor,TX,state,0.4831,1000.0,2026-02-03,GBAO (D),D=43.0% R=46.0%; LV; src=wikipedia
-2026 TX Governor,TX,state,0.4615,1502.0,2026-02-11,Univ. of Houston,D=42.0% R=49.0%; LV; src=270towin
-2026 TX Governor,TX,state,0.4556,1117.0,2026-02-22,UT Tyler,D=41.0% R=49.0%; RV; src=wikipedia
-2026 TX Governor,TX,state,0.4556,959.0,2026-02-27,Univ. of Texas - Tyler,D=41.0% R=49.0%; LV; src=270towin
-2026 TX Senate,TX,state,0.5,1165.0,2026-01-12,Emerson College,D=46.0% R=46.0%; LV; src=rcp
-2026 TX Senate,TX,state,0.4889,1502.0,2026-01-31,University of Houston,D=44.0% R=46.0%; LV; src=rcp
-2026 WI Governor,WI,state,0.4819,500.0,2025-09-30,Platform Communications,D=40.0% R=43.0%; LV; src=wikipedia
-2026 WI Governor,WI,state,0.5319,500.0,2025-10-08,Impact Research (D),D=50.0% R=44.0%; LV; src=wikipedia
-2026 WI Governor,WI,state,0.5119,1175.0,2026-03-19,TIPP Insights (R),D=43.0% R=41.0%; LV; src=wikipedia
-2026 WI Governor,WI,state,0.4819,1175.0,2026-03-23,TIPP Insights,D=40.0% R=43.0%; LV; src=270towin
+race,geography,geo_level,dem_share,n_sample,date,pollster,notes,methodology,xt_education_college,xt_education_noncollege,xt_race_white,xt_race_black,xt_race_hispanic,xt_race_asian,xt_urbanicity_urban,xt_urbanicity_rural,xt_age_senior,xt_religion_evangelical,xt_vote_race_white,xt_vote_race_black,xt_vote_race_hispanic,xt_vote_race_asian,xt_vote_education_college,xt_vote_education_noncollege,xt_vote_age_senior
+2026 AL Governor,AL,state,0.3908,605.0,2025-11-13,Cygnal,D=34.0% R=53.0%; LV; src=wikipedia,IVR,,,,,,,,,,,,,,,,,
+2026 AZ Governor,AZ,state,0.5057,850.0,2025-11-10,Emerson College,D=44.0% R=43.0%; RV; src=rcp,mixed,0.355,0.645,0.712,0.026,0.187,0.022,,,0.39,,0.416,0.572,0.474,0.477,0.545,0.403,0.4385
+2026 AZ Governor,AZ,state,0.5316,1023.0,2026-02-26,Noble Predictive Insights,D=42.0% R=37.0%; RV; src=rcp,mixed,,,,,,,,,,,,,,,,,
+2026 FL Governor,FL,state,0.4607,600.0,2024-10-28,Cygnal,D=41.0% R=48.0%; LV; src=wikipedia,IVR,,,,,,,,,,,,,,,,,
+2026 FL Governor,FL,state,0.4722,1200.0,2025-05-07,Targoz Market Research,D=34.0% R=38.0%; RV; src=wikipedia,online,,,,,,,,,,,,,,,,,
+2026 FL Governor,FL,state,0.4559,600.0,2025-06-10,Victory Insights,D=31.0% R=37.0%; LV; src=wikipedia,online,,,,,,,,,,,,,,,,,
+2026 FL Governor,FL,state,0.4556,800.0,2025-08-27,AIF Center (R),D=41.0% R=49.0%; LV; src=wikipedia,online,,,,,,,,,,,,,,,,,
+2026 FL Governor,FL,state,0.427,1000.0,2025-08-27,Cygnal,D=38.0% R=51.0%; LV; src=wikipedia,IVR,,,,,,,,,,,,,,,,,
+2026 FL Governor,FL,state,0.5062,631.0,2025-09-09,Bendixen & Amandi International,D=41.0% R=40.0%; LV; src=wikipedia,mixed,,,,,,,,,,,,,,,,,
+2026 FL Governor,FL,state,0.4706,1118.0,2025-09-18,Targoz Market Research,D=32.0% R=36.0%; RV; src=wikipedia,online,,,,,,,,,,,,,,,,,
+2026 FL Governor,FL,state,0.4231,728.0,2025-10-25,University of North Florida,D=33.0% R=45.0%; LV; src=wikipedia,phone,,,,,,,,,,,,,,,,,
+2026 FL Governor,FL,state,0.4337,728.0,2025-10-28,University of North Florida,D=36.0% R=47.0%; LV; src=270towin,phone,,,,,,,,,,,,,,,,,
+2026 FL Governor,FL,state,0.4675,1129.0,2026-02-16,Targoz Market Research,D=36.0% R=41.0%; LV; src=wikipedia,online,,,,,,,,,,,,,,,,,
+2026 FL Governor,FL,state,0.4557,786.0,2026-03-02,University of North Florida,D=36.0% R=43.0%; LV; src=rcp,phone,,,,,,,,,,,,,,,,,
+2026 FL Governor,FL,state,0.4557,786.0,2026-03-04,University of North Florida,D=36.0% R=43.0%; LV; src=270towin,phone,,,,,,,,,,,,,,,,,
+2026 FL Governor,FL,state,0.4444,1125.0,2026-03-31,Emerson College,D=36.0% R=45.0%; LV; src=rcp,mixed,0.482,0.518,0.556,0.178,0.214,0.01,,,0.492,,0.323,0.636,0.411,0.241,0.4525,0.336,0.396
+2026 FL Governor,FL,state,0.4875,1125.0,2026-04-02,Emerson College,D=39.0% R=41.0%; LV; src=270towin,mixed,0.482,0.518,0.556,0.178,0.214,0.01,,,0.492,,0.323,0.636,0.411,0.241,0.4525,0.336,0.396
+2026 FL Governor,FL,state,0.5,1834.0,2026-04-03,MDW (D),D=41.0% R=41.0%; LV; src=wikipedia,,,,,,,,,,,,,,,,,,
+2026 FL Governor,FL,state,0.4762,795.0,2026-04-06,Keystone Analytics,D=40.0% R=44.0%; LV; src=wikipedia,,,,,,,,,,,,,,,,,,
+2026 FL Governor,FL,state,0.5,1834.0,2026-04-13,Edge / MDW Communications,D=41.0% R=41.0%; LV; src=270towin,,,,,,,,,,,,,,,,,,
+2026 FL Senate,FL,state,0.4568,800.0,2025-10-03,Tyson Group,D=37.0% R=44.0%; LV; src=wikipedia,mixed,,,,,,,,,,,,,,,,,
+2026 FL Senate,FL,state,0.4368,728.0,2025-10-25,University of North Florida,D=38.0% R=49.0%; LV; src=wikipedia,phone,,,,,,,,,,,,,,,,,
+2026 FL Senate,FL,state,0.4524,786.0,2026-03-02,University of North Florida,D=38.0% R=46.0%; LV; src=wikipedia,phone,,,,,,,,,,,,,,,,,
+2026 FL Senate,FL,state,0.4524,786.0,2026-03-04,University of North Florida,D=38.0% R=46.0%; LV; src=270towin,phone,,,,,,,,,,,,,,,,,
+2026 FL Senate,FL,state,0.4337,1125.0,2026-03-31,Emerson College,D=36.0% R=47.0%; LV; src=wikipedia,mixed,0.482,0.518,0.556,0.178,0.214,0.01,,,0.492,,0.323,0.636,0.411,0.241,0.4525,0.336,0.396
+2026 FL Senate,FL,state,0.4337,1125.0,2026-04-02,Emerson College,D=36.0% R=47.0%; LV; src=270towin,mixed,0.482,0.518,0.556,0.178,0.214,0.01,,,0.492,,0.323,0.636,0.411,0.241,0.4525,0.336,0.396
+2026 FL Senate,FL,state,0.4941,1834.0,2026-04-03,MDW (D),D=42.0% R=43.0%; LV; src=wikipedia,,,,,,,,,,,,,,,,,,
+2026 FL Senate,FL,state,0.4941,1834.0,2026-04-13,Edge / MDW Communications,D=42.0% R=43.0%; LV; src=270towin,,,,,,,,,,,,,,,,,,
+2026 GA Senate,GA,state,0.5844,500.0,2025-01-15,WPA Intelligence,D=45.0% R=32.0%; LV; src=wikipedia,online,,,,,,,,,,,,,,,,,
+2026 GA Senate,GA,state,0.5465,600.0,2025-01-31,Tyson Group,D=47.0% R=39.0%; LV; src=wikipedia,mixed,,,,,,,,,,,,,,,,,
+2026 GA Senate,GA,state,0.5465,600.0,2025-02-11,Tyson Group,D=47.0% R=39.0%; LV; src=270towin,mixed,,,,,,,,,,,,,,,,,
+2026 GA Senate,GA,state,0.4839,800.0,2025-02-13,Quantus Insights,D=45.0% R=48.0%; RV; src=wikipedia,online,,,,,,,,,,,,,,,,,
+2026 GA Senate,GA,state,0.5,600.0,2025-03-10,Cygnal,D=44.0% R=44.0%; LV; src=wikipedia,IVR,,,,,,,,,,,,,,,,,
+2026 GA Senate,GA,state,0.5517,1000.0,2025-04-24,Atlanta Journal-Constitution,D=48.0% R=39.0%; RV; src=wikipedia,unknown,,,,,,,,,,,,,,,,,
+2026 GA Senate,GA,state,0.5275,1426.0,2025-04-27,Trafalgar Group,D=48.0% R=43.0%; LV; src=wikipedia,mixed,,,,,,,,,,,,,,,,,
+2026 GA Senate,GA,state,0.5227,800.0,2025-05-17,Cygnal,D=46.0% R=42.0%; LV; src=rcp,IVR,,,,,,,,,,,,,,,,,
+2026 GA Senate,GA,state,0.5169,800.0,2025-05-22,Cygnal,D=46.0% R=43.0%; LV; src=270towin,IVR,,,,,,,,,,,,,,,,,
+2026 GA Senate,GA,state,0.5385,610.0,2025-06-18,Cygnal,D=49.0% R=42.0%; LV; src=wikipedia,IVR,,,,,,,,,,,,,,,,,
+2026 GA Senate,GA,state,0.5238,2956.0,2025-08-01,TIPP Insights,D=44.0% R=40.0%; RV; src=rcp,mixed,,,,,,,,,,,,,,,,,
+2026 GA Senate,GA,state,0.5195,624.0,2025-09-12,Quantus Insights,D=40.0% R=37.0%; RV; src=rcp,online,,,,,,,,,,,,,,,,,
+2026 GA Senate,GA,state,0.5455,624.0,2025-09-15,Quantus Insights,D=42.0% R=35.0%; LV; src=270towin,online,,,,,,,,,,,,,,,,,
+2026 GA Senate,GA,state,0.5165,1000.0,2026-03-02,Emerson College,D=47.0% R=44.0%; LV; src=rcp,mixed,0.395,0.605,0.602,0.286,0.081,0.017,,,0.355,,0.348,0.768,0.361,0.596,0.585,0.389,0.455
+2026 GA Senate,GA,state,0.5444,1000.0,2026-03-05,Emerson College,D=49.0% R=41.0%; LV; src=270towin,mixed,0.395,0.605,0.602,0.286,0.081,0.017,,,0.355,,0.348,0.768,0.361,0.596,0.585,0.389,0.455
+2026 Generic Ballot,US,national,0.5464,1392.0,2026-03-04,NPR,D=53.0% R=44.0%; RV; src=rcp,phone,,,,,,,,,,,,,,,,,
+2026 Generic Ballot,US,national,0.5238,1147.0,2026-03-16,Yahoo News,D=44.0% R=40.0%; RV; src=rcp,unknown,,,,,,,,,,,,,,,,,
+2026 Generic Ballot,US,national,0.5385,1000.0,2026-03-17,Emerson College,D=49.0% R=42.0%; LV; src=rcp,mixed,,,,,,,,,,,,,,,,,
+2026 Generic Ballot,US,national,0.5128,985.0,2026-03-23,Reuters,D=40.0% R=38.0%; RV; src=rcp,phone,,,,,,,,,,,,,,,,,
+2026 Generic Ballot,US,national,0.5604,1191.0,2026-03-23,Quinnipiac University,D=51.0% R=40.0%; RV; src=rcp,phone,,,,,,,,,,,,,,,,,
+2026 Generic Ballot,US,national,0.5172,2222.0,2026-03-23,Rasmussen Reports,D=45.0% R=42.0%; LV; src=rcp,mixed,,,,,,,,,,,,,,,,,
+2026 Generic Ballot,US,national,0.5455,3003.0,2026-03-24,Big Data Poll,D=48.0% R=40.0%; LV; src=rcp,online,,,,,,,,,,,,,,,,,
+2026 Generic Ballot,US,national,0.52,,2026-03-26,Harvard-Harris,D=52.0% R=48.0%; LV; src=rcp,online,,,,,,,,,,,,,,,,,
+2026 Generic Ballot,US,national,0.5341,1472.0,2026-03-26,Quantus Insights,D=47.0% R=41.0%; LV; src=rcp,online,,,,,,,,,,,,,,,,,
+2026 Generic Ballot,US,national,0.5333,952.0,2026-03-30,CNN,D=48.0% R=42.0%; RV; src=rcp,phone,,,,,,,,,,,,,,,,,
+2026 Generic Ballot,US,national,0.5326,1500.0,2026-04-03,Cygnal,D=49.0% R=43.0%; LV; src=rcp,,,,,,,,,,,,,,,,,,
+2026 Generic Ballot,US,national,0.5172,2200.0,2026-04-05,Morning Consult,D=45.0% R=42.0%; RV; src=rcp,,,,,,,,,,,,,,,,,,
+2026 Generic Ballot,US,national,0.5116,1560.0,2026-04-06,Economist/YouGov,D=44.0% R=42.0%; RV; src=rcp,,,,,,,,,,,,,,,,,,
+2026 Generic Ballot,US,national,0.5269,2000.0,2026-04-09,RMG Research,D=49.0% R=44.0%; RV; src=rcp,,,,,,,,,,,,,,,,,,
+2026 Generic Ballot,US,national,0.5294,1573.0,2026-04-13,Economist/YouGov,D=45.0% R=40.0%; RV; src=rcp,,,,,,,,,,,,,,,,,,
+2026 Generic Ballot,US,national,0.5172,2203.0,2026-04-20,Morning Consult,D=45.0% R=42.0%; RV; src=rcp,,,,,,,,,,,,,,,,,,
+2026 IA Senate,IA,state,0.4824,1108.0,2026-01-11,Change Research (D),D=41.0% R=44.0%; LV; src=wikipedia,online,,,,,,,,,,,,,,,,,
+2026 IA Senate,IA,state,0.4778,1200.0,2026-03-16,GQR (D),D=43.0% R=47.0%; LV; src=wikipedia,,,,,,,,,,,,,,,,,,
+2026 MA Senate,MA,state,0.6353,500.0,2025-11-23,Boston Globe/Suffolk,D=54.0% R=31.0%; RV; src=rcp,phone,,,,,,,,,,,,,,,,,
+2026 MA Senate,MA,state,0.6747,620.0,2026-02-16,UNH,D=56.0% R=27.0%; LV; src=rcp,phone,,,,,,,,,,,,,,,,,
+2026 ME Senate,ME,state,0.5316,501.0,2025-10-10,Zenith Research (D),D=42.0% R=37.0%; LV; src=wikipedia,online,,,,,,,,,,,,,,,,,
+2026 ME Senate,ME,state,0.4773,783.0,2025-10-29,Maine People's Resource Center,D=42.0% R=46.0%; LV; src=wikipedia,unknown,,,,,,,,,,,,,,,,,
+2026 ME Senate,ME,state,0.5444,600.0,2025-11-11,Cygnal,D=49.0% R=41.0%; LV; src=wikipedia,IVR,,,,,,,,,,,,,,,,,
+2026 ME Senate,ME,state,0.4773,783.0,2025-11-12,Maine People's Resource Center,D=42.0% R=46.0%; RV; src=270towin,unknown,,,,,,,,,,,,,,,,,
+2026 ME Senate,ME,state,0.5,820.0,2025-12-07,Pan Atlantic Research,D=43.0% R=43.0%; LV; src=wikipedia,phone,,,,,,,,,,,,,,,,,
+2026 ME Senate,ME,state,0.5,820.0,2025-12-10,Pan Atlantic Research,D=43.0% R=43.0%; LV; src=270towin,phone,,,,,,,,,,,,,,,,,
+2026 ME Senate,ME,state,0.49,900.0,2025-12-16,Workbench Strategy (D),D=49.0% R=51.0%; LV; src=wikipedia,online,,,,,,,,,,,,,,,,,
+2026 ME Senate,ME,state,0.4944,800.0,2026-01-24,Fabrizio Lee & Associates,D=44.0% R=45.0%; LV; src=wikipedia,phone,,,,,,,,,,,,,,,,,
+2026 ME Senate,ME,state,0.5632,1120.0,2026-02-16,UNH,D=49.0% R=38.0%; LV; src=rcp,phone,,,,,,,,,,,,,,,,,
+2026 ME Senate,ME,state,0.5062,1105.0,2026-02-16,University of New Hampshire,D=41.0% R=40.0%; LV; src=wikipedia,phone,,,,,,,,,,,,,,,,,
+2026 ME Senate,ME,state,0.5062,1120.0,2026-02-24,Univ. of New Hampshire,D=41.0% R=40.0%; LV; src=270towin,phone,,,,,,,,,,,,,,,,,
+2026 ME Senate,ME,state,0.5238,810.0,2026-03-02,Pan Atlantic,D=44.0% R=40.0%; LV; src=rcp,phone,,,,,,,,,,,,,,,,,
+2026 ME Senate,ME,state,0.5,810.0,2026-03-02,Pan Atlantic Research,D=44.0% R=44.0%; LV; src=wikipedia,phone,,,,,,,,,,,,,,,,,
+2026 ME Senate,ME,state,0.5,810.0,2026-03-04,Pan Atlantic Research,D=44.0% R=44.0%; LV; src=270towin,phone,,,,,,,,,,,,,,,,,
+2026 ME Senate,ME,state,0.5385,800.0,2026-03-05,Quantus Insights,D=49.0% R=42.0%; LV; src=rcp,online,,,,,,,,,,,,,,,,,
+2026 ME Senate,ME,state,0.5,600.0,2026-03-08,OnMessage Public Strategies (R),D=42.0% R=42.0%; LV; src=wikipedia,mixed,,,,,,,,,,,,,,,,,
+2026 ME Senate,ME,state,0.4886,800.0,2026-03-09,Quantus Insights,D=43.0% R=45.0%; LV; src=270towin,online,,,,,,,,,,,,,,,,,
+2026 ME Senate,ME,state,0.5,600.0,2026-03-10,OnMessage,D=42.0% R=42.0%; LV; src=270towin,mixed,,,,,,,,,,,,,,,,,
+2026 ME Senate,ME,state,0.5393,1075.0,2026-03-23,Emerson College,D=48.0% R=41.0%; LV; src=rcp,mixed,0.44,0.56,0.912,,,,,,0.452,,,,,,0.6295,0.37,0.484
+2026 ME Senate,ME,state,0.5169,1075.0,2026-03-26,Emerson College,D=46.0% R=43.0%; LV; src=270towin,mixed,0.44,0.56,0.912,,,,,,0.452,,,,,,0.6295,0.37,0.484
+2026 ME Senate,ME,state,0.5517,1167.0,2026-03-31,MPRC,D=48.0% R=39.0%; LV; src=rcp,,,,,,,,,,,,,,,,,,
+2026 ME Senate,ME,state,0.4828,1167.0,2026-03-31,Maine People's Resource Center (D),D=42.0% R=45.0%; LV; src=wikipedia,,,,,,,,,,,,,,,,,,
+2026 ME Senate,ME,state,0.4828,1167.0,2026-04-07,Maine People's Resource Center,D=42.0% R=45.0%; LV; src=270towin,,,,,,,,,,,,,,,,,,
+2026 ME Senate,ME,state,0.4977,,,Decision Desk HQ,D=43.4% R=43.8%; src=wikipedia,online,,,,,,,,,,,,,,,,,
+2026 MI Governor,MI,state,0.5833,600.0,2025-02-08,Target Insyght,D=42.0% R=30.0%; src=wikipedia,online,,,,,,,,,,,,,,,,,
+2026 MI Governor,MI,state,0.5,600.0,2025-02-08,EPIC-MRA,D=31.0% R=31.0%; LV; src=wikipedia,phone,,,,,,,,,,,,,,,,,
+2026 MI Governor,MI,state,0.5833,600.0,2025-03-08,Target Insyght,D=42.0% R=30.0%; RV; src=270towin,online,,,,,,,,,,,,,,,,,
+2026 MI Governor,MI,state,0.5211,688.0,2025-03-13,Mitchell Research,D=37.0% R=34.0%; LV; src=wikipedia,phone,,,,,,,,,,,,,,,,,
+2026 MI Governor,MI,state,0.5211,688.0,2025-03-18,Mitchell Research,D=37.0% R=34.0%; LV; src=270towin,phone,,,,,,,,,,,,,,,,,
+2026 MI Governor,MI,state,0.5072,600.0,2025-05-28,Glengariff Group,D=35.0% R=34.0%; RV; src=270towin,phone,,,,,,,,,,,,,,,,,
+2026 MI Governor,MI,state,0.4658,252.0,2025-10-25,Rosetta Stone,D=34.0% R=39.0%; LV; src=rcp,mixed,,,,,,,,,,,,,,,,,
+2026 MI Governor,MI,state,0.4658,637.0,2025-10-25,Rosetta Stone Communications (R),D=34.0% R=39.0%; LV; src=wikipedia,mixed,,,,,,,,,,,,,,,,,
+2026 MI Governor,MI,state,0.4658,637.0,2025-11-06,Rosetta Stone,D=34.0% R=39.0%; LV; src=270towin,mixed,,,,,,,,,,,,,,,,,
+2026 MI Governor,MI,state,0.4925,600.0,2025-11-11,EPIC-MRA,D=33.0% R=34.0%; RV; src=rcp,phone,,,,,,,,,,,,,,,,,
+2026 MI Governor,MI,state,0.4925,600.0,2025-11-14,EPIC-MRA,D=33.0% R=34.0%; LV; src=270towin,phone,,,,,,,,,,,,,,,,,
+2026 MI Governor,MI,state,0.4559,616.0,2025-11-21,Mitchell Research,D=31.0% R=37.0%; LV; src=rcp,phone,,,,,,,,,,,,,,,,,
+2026 MI Governor,MI,state,0.4559,616.0,2025-12-02,Mitchell Research,D=31.0% R=37.0%; LV; src=270towin,phone,,,,,,,,,,,,,,,,,
+2026 MI Governor,MI,state,0.4848,600.0,2026-01-06,Detroit News,D=32.0% R=34.0%; LV; src=rcp,phone,,,,,,,,,,,,,,,,,
+2026 MI Governor,MI,state,0.4745,,2026-01-06,Real Clear Politics,D=32.5% R=36.0%; src=wikipedia,unknown,,,,,,,,,,,,,,,,,
+2026 MI Governor,MI,state,0.4848,600.0,2026-01-06,Glengariff Group,D=32.0% R=34.0%; LV; src=wikipedia,phone,,,,,,,,,,,,,,,,,
+2026 MI Governor,MI,state,0.4848,600.0,2026-01-13,Glengariff Group,D=32.0% R=34.0%; LV; src=270towin,phone,,,,,,,,,,,,,,,,,
+2026 MI Governor,MI,state,0.4912,,2026-02-02,Glengariff Group,D=28.0% R=29.0%; LV; src=wikipedia,phone,,,,,,,,,,,,,,,,,
+2026 MI Governor,MI,state,0.52,800.0,2026-02-16,Impact Research (D),D=39.0% R=36.0%; LV; src=wikipedia,online,,,,,,,,,,,,,,,,,
+2026 MI Governor,MI,state,0.587,1000.0,2026-03-24,Michigan State University/YouGov,D=27.0% R=19.0%; src=wikipedia,,,,,,,,,,,,,,,,,,
+2026 MI Governor,MI,state,0.5263,800.0,2026-03-29,Impact Research (D),D=40.0% R=36.0%; LV; src=wikipedia,,,,,,,,,,,,,,,,,,
+2026 MI Governor,MI,state,0.566,1000.0,2026-04-20,Michigan State Univ.,D=30.0% R=23.0%; src=270towin,,,,,,,,,,,,,,,,,,
+2026 MI Governor,MI,state,0.5085,600.0,,Schoen Cooperman Research (D),D=30.0% R=29.0%; LV; src=wikipedia,phone,,,,,,,,,,,,,,,,,
+2026 MI Governor,MI,state,0.5072,600.0,,Glengariff Group,D=35.0% R=34.0%; RV; src=wikipedia,phone,,,,,,,,,,,,,,,,,
+2026 MI Governor,MI,state,0.4697,600.0,,Plymouth Union Public (R),D=31.0% R=35.0%; LV; src=wikipedia,mixed,,,,,,,,,,,,,,,,,
+2026 MI Senate,MI,state,0.4659,600.0,2025-02-08,EPIC-MRA,D=41.0% R=47.0%; src=wikipedia,phone,,,,,,,,,,,,,,,,,
+2026 MI Senate,MI,state,0.4605,600.0,2025-03-06,Target Insyght,D=35.0% R=41.0%; src=wikipedia,online,,,,,,,,,,,,,,,,,
+2026 MI Senate,MI,state,0.5056,688.0,2025-03-13,Mitchell Research,D=45.0% R=44.0%; LV; src=wikipedia,phone,,,,,,,,,,,,,,,,,
+2026 MI Senate,MI,state,0.5056,600.0,2025-05-08,Glengariff Group,D=45.0% R=44.0%; RV; src=wikipedia,phone,,,,,,,,,,,,,,,,,
+2026 MI Senate,MI,state,0.5109,700.0,2025-06-16,Normington Petts (D),D=47.0% R=45.0%; LV; src=wikipedia,phone,,,,,,,,,,,,,,,,,
+2026 MI Senate,MI,state,0.4598,637.0,2025-10-25,Rosetta Stone Communications (R),D=40.0% R=47.0%; LV; src=wikipedia,mixed,,,,,,,,,,,,,,,,,
+2026 MI Senate,MI,state,0.5116,600.0,2025-11-11,EPIC-MRA,D=44.0% R=42.0%; RV; src=wikipedia,phone,,,,,,,,,,,,,,,,,
+2026 MI Senate,MI,state,0.4878,616.0,2025-11-21,Mitchell Research & Communications,D=40.0% R=42.0%; LV; src=wikipedia,phone,,,,,,,,,,,,,,,,,
+2026 MI Senate,MI,state,0.5281,600.0,2026-01-06,Glengariff Group,D=47.0% R=42.0%; LV; src=wikipedia,phone,,,,,,,,,,,,,,,,,
+2026 MI Senate,MI,state,0.5281,1000.0,2026-01-25,Emerson College,D=47.0% R=42.0%; LV; src=wikipedia,mixed,0.363,0.637,0.768,0.125,0.059,0.013,,,0.394,,0.44,0.664,0.532,0.505,0.573,0.4255,0.4685
+2026 MN Governor,MN,state,0.5904,575.0,2026-01-30,SurveyUSA,D=49.0% R=34.0%; RV; src=rcp,mixed,,,,,,,,,,,,,,,,,
+2026 MN Governor,MN,state,0.573,1000.0,2026-02-08,Emerson College,D=51.0% R=38.0%; RV; src=rcp,mixed,0.441,0.559,0.847,0.058,0.025,0.022,,,0.413,,0.426,0.237,0.334,0.17,0.328,0.471,0.4575
+2026 MN Senate,MN,state,0.5213,604.0,2025-07-11,Impact Research (D),D=49.0% R=45.0%; LV; src=wikipedia,online,,,,,,,,,,,,,,,,,
+2026 MN Senate,MN,state,0.5402,1000.0,2026-02-08,Emerson College,D=47.0% R=40.0%; LV; src=wikipedia,mixed,0.441,0.559,0.847,0.058,0.025,0.022,,,0.413,,0.426,0.237,0.334,0.17,0.328,0.471,0.4575
+2026 MN Senate,MN,state,0.5402,1000.0,2026-02-11,Emerson College,D=47.0% R=40.0%; LV; src=270towin,mixed,0.441,0.559,0.847,0.058,0.025,0.022,,,0.413,,0.426,0.237,0.334,0.17,0.328,0.471,0.4575
+2026 NC Senate,NC,state,0.5056,800.0,2024-11-29,Victory Insights,D=45.0% R=44.0%; LV; src=wikipedia,online,,,,,,,,,,,,,,,,,
+2026 NC Senate,NC,state,0.5111,867.0,2025-04-04,Change Research (D),D=46.0% R=44.0%; LV; src=wikipedia,online,,,,,,,,,,,,,,,,,
+2026 NC Senate,NC,state,0.5341,1000.0,2025-07-30,Emerson College,D=47.0% R=41.0%; RV; src=wikipedia,mixed,,,,,,,,,,,,,,,,,
+2026 NC Senate,NC,state,0.5181,600.0,2025-07-30,Victory Insights,D=43.0% R=40.0%; LV; src=wikipedia,online,,,,,,,,,,,,,,,,,
+2026 NC Senate,NC,state,0.5181,600.0,2025-07-31,Victory Insights,D=43.0% R=40.0%; LV; src=270towin,online,,,,,,,,,,,,,,,,,
+2026 NC Senate,NC,state,0.5341,1000.0,2025-08-01,Emerson College,D=47.0% R=41.0%; RV; src=270towin,mixed,,,,,,,,,,,,,,,,,
+2026 NC Senate,NC,state,0.5393,855.0,2025-09-08,Change Research (D),D=48.0% R=41.0%; LV; src=wikipedia,online,,,,,,,,,,,,,,,,,
+2026 NC Senate,NC,state,0.5281,1105.0,2026-01-07,Change Research (D),D=47.0% R=42.0%; LV; src=wikipedia,online,,,,,,,,,,,,,,,,,
+2026 NC Senate,NC,state,0.6667,1512.0,2026-01-15,TIPP Insights (R),D=48.0% R=24.0%; RV; src=wikipedia,mixed,,,,,,,,,,,,,,,,,
+2026 NC Senate,NC,state,0.5556,1069.0,2026-02-04,Change Research,D=50.0% R=40.0%; LV; src=rcp,online,,,,,,,,,,,,,,,,,
+2026 NC Senate,NC,state,0.5556,1069.0,2026-02-04,Change Research (D),D=50.0% R=40.0%; RV; src=wikipedia,online,,,,,,,,,,,,,,,,,
+2026 NC Senate,NC,state,0.5556,1069.0,2026-02-20,Change Research,D=50.0% R=40.0%; RV; src=270towin,online,,,,,,,,,,,,,,,,,
+2026 NC Senate,NC,state,0.6098,800.0,2026-03-09,Nexus Strategies/ Strategic Partners Solutions,D=50.0% R=32.0%; RV; src=wikipedia,mixed,,,,,,,,,,,,,,,,,
+2026 NC Senate,NC,state,0.5165,556.0,2026-03-14,Public Policy Polling,D=47.0% R=44.0%; RV; src=rcp,IVR,,,,,,,,,,,,,,,,,
+2026 NC Senate,NC,state,0.5854,1000.0,2026-03-18,Catawba College/YouGov,D=48.0% R=34.0%; LV; src=wikipedia,phone,,,,,,,,,,,,,,,,,
+2026 NC Senate,NC,state,0.5444,600.0,2026-03-23,Carolina Journal/Harper,D=49.0% R=41.0%; LV; src=rcp,unknown,,,,,,,,,,,,,,,,,
+2026 NC Senate,NC,state,0.6098,800.0,2026-03-27,Nexus/Strategic Partners Solutions,D=50.0% R=32.0%; LV; src=270towin,mixed,,,,,,,,,,,,,,,,,
+2026 NC Senate,NC,state,0.5854,871.0,2026-03-31,Catawba College,D=48.0% R=34.0%; LV; src=270towin,phone,,,,,,,,,,,,,,,,,
+2026 NC Senate,NC,state,0.5269,987.0,2026-04-01,Quantus Insights,D=49.0% R=44.0%; LV; src=rcp,online,,,,,,,,,,,,,,,,,
+2026 NC Senate,NC,state,0.5269,987.0,2026-04-02,Quantus Insights,D=49.0% R=44.0%; LV; src=270towin,online,,,,,,,,,,,,,,,,,
+2026 NC Senate,NC,state,0.5435,703.0,2026-04-06,High Point/YouGov,D=50.0% R=42.0%; LV; src=rcp,,,,,,,,,,,,,,,,,,
+2026 NC Senate,NC,state,0.5435,703.0,2026-04-06,High Point University/YouGov,D=50.0% R=42.0%; LV; src=wikipedia,,,,,,,,,,,,,,,,,,
+2026 NC Senate,NC,state,0.5435,703.0,2026-04-17,High Point Univ.,D=50.0% R=42.0%; LV; src=270towin,,,,,,,,,,,,,,,,,,
+2026 NH Governor,NH,state,0.4382,2053.0,2026-01-19,UNH,D=39.0% R=50.0%; LV; src=rcp,phone,,,,,,,,,,,,,,,,,
+2026 NH Governor,NH,state,0.4079,1491.0,2026-03-18,St. Anselm,D=31.0% R=45.0%; RV; src=rcp,phone,,,,,,,,,,,,,,,,,
+2026 NH Senate,NH,state,0.46,626.0,2025-03-01,Praecones Analytica,D=46.0% R=54.0%; RV; src=wikipedia,online,,,,,,,,,,,,,,,,,
+2026 NH Senate,NH,state,0.4536,650.0,2025-03-19,Quantus Insights,D=44.0% R=53.0%; RV; src=wikipedia,online,,,,,,,,,,,,,,,,,
+2026 NH Senate,NH,state,0.5647,1776.0,2025-08-27,Saint Anselm College,D=48.0% R=37.0%; RV; src=wikipedia,phone,,,,,,,,,,,,,,,,,
+2026 NH Senate,NH,state,0.5647,1776.0,2025-09-05,Saint Anselm College,D=48.0% R=37.0%; RV; src=270towin,phone,,,,,,,,,,,,,,,,,
+2026 NH Senate,NH,state,0.5556,904.0,2025-09-12,co/efficient (R),D=50.0% R=40.0%; LV; src=wikipedia,online,,,,,,,,,,,,,,,,,
+2026 NH Senate,NH,state,0.5169,904.0,2025-09-15,co/efficient,D=46.0% R=43.0%; LV; src=270towin,online,,,,,,,,,,,,,,,,,
+2026 NH Senate,NH,state,0.5843,1235.0,2025-09-23,University of New Hampshire,D=52.0% R=37.0%; LV; src=wikipedia,phone,,,,,,,,,,,,,,,,,
+2026 NH Senate,NH,state,0.5326,1235.0,2025-09-29,Univ. of New Hampshire,D=49.0% R=43.0%; LV; src=270towin,phone,,,,,,,,,,,,,,,,,
+2026 NH Senate,NH,state,0.5568,1034.0,2025-10-13,co/efficient (R),D=49.0% R=39.0%; LV; src=wikipedia,online,,,,,,,,,,,,,,,,,
+2026 NH Senate,NH,state,0.5172,1034.0,2025-10-15,co/efficient,D=45.0% R=42.0%; LV; src=270towin,online,,,,,,,,,,,,,,,,,
+2026 NH Senate,NH,state,0.55,2212.0,2025-11-19,Saint Anselm College,D=44.0% R=36.0%; RV; src=wikipedia,phone,,,,,,,,,,,,,,,,,
+2026 NH Senate,NH,state,0.5176,2212.0,2025-11-24,Univ. of New Hampshire,D=44.0% R=41.0%; RV; src=270towin,phone,,,,,,,,,,,,,,,,,
+2026 NH Senate,NH,state,0.6216,603.0,2025-12-28,NHJournal/Praecones Analytica,D=46.0% R=28.0%; RV; src=wikipedia,phone,,,,,,,,,,,,,,,,,
+2026 NH Senate,NH,state,0.5385,603.0,2026-01-04,NH Journal,D=42.0% R=36.0%; RV; src=270towin,phone,,,,,,,,,,,,,,,,,
+2026 NH Senate,NH,state,0.5263,2053.0,2026-01-19,UNH,D=50.0% R=45.0%; LV; src=rcp,phone,,,,,,,,,,,,,,,,,
+2026 NH Senate,NH,state,0.5532,2053.0,2026-01-19,University of New Hampshire,D=52.0% R=42.0%; LV; src=wikipedia,phone,,,,,,,,,,,,,,,,,
+2026 NH Senate,NH,state,0.5263,2053.0,2026-01-21,Univ. of New Hampshire,D=50.0% R=45.0%; LV; src=270towin,phone,,,,,,,,,,,,,,,,,
+2026 NH Senate,NH,state,0.5233,563.0,2026-01-29,yes. every kid.,D=45.0% R=41.0%; LV; src=wikipedia,unknown,,,,,,,,,,,,,,,,,
+2026 NH Senate,NH,state,0.5169,1491.0,2026-03-18,St. Anselm,D=46.0% R=43.0%; RV; src=rcp,phone,,,,,,,,,,,,,,,,,
+2026 NH Senate,NH,state,0.5529,1491.0,2026-03-18,Saint Anselm College,D=47.0% R=38.0%; RV; src=wikipedia,phone,,,,,,,,,,,,,,,,,
+2026 NH Senate,NH,state,0.5169,1491.0,2026-03-23,Saint Anselm College,D=46.0% R=43.0%; RV; src=270towin,phone,,,,,,,,,,,,,,,,,
+2026 NH Senate,NH,state,0.5056,1100.0,2026-03-23,Emerson College,D=45.0% R=44.0%; LV; src=rcp,mixed,0.512,0.488,,,,,,,0.411,,,,,,0.5565,0.3575,0.444
+2026 NH Senate,NH,state,0.5056,1100.0,2026-03-26,Emerson College,D=45.0% R=44.0%; LV; src=270towin,mixed,0.512,0.488,,,,,,,0.411,,,,,,0.5565,0.3575,0.444
+2026 NV Governor,NV,state,0.5,800.0,2025-11-18,Emerson College,D=41.0% R=41.0%; RV; src=rcp,mixed,0.339,0.661,0.634,0.069,0.169,0.051,,,0.387,,0.361,0.646,0.48,0.483,0.4955,0.3605,0.4
+2026 NV Governor,NV,state,0.4935,845.0,2026-03-13,Noble Predictive Insights,D=38.0% R=39.0%; RV; src=rcp,mixed,,,,,,,,,,,,,,,,,
+2026 NY Governor,NY,state,0.6024,1442.0,2026-02-19,Marist College,D=50.0% R=33.0%; RV; src=rcp,phone,0.44,0.56,0.63,0.13,0.13,,,,0.34,,0.528736,0.908046,0.756757,,0.647727,0.567901,0.606742
+2026 NY Governor,NY,state,0.5802,804.0,2026-03-26,Siena College,D=47.0% R=34.0%; RV; src=rcp,phone,,,,,,,,,,,,,,,,,
+2026 OH Governor,OH,state,0.4737,800.0,2025-04-24,Bowling Green State University/YouGov,D=45.0% R=50.0%; RV; src=wikipedia,online,,,,,,,,,,,,,,,,,
+2026 OH Governor,OH,state,0.4737,800.0,2025-04-29,Bowling Green Univ.,D=45.0% R=50.0%; RV; src=270towin,online,,,,,,,,,,,,,,,,,
+2026 OH Governor,OH,state,0.4946,800.0,2025-07-28,Impact Research (D),D=46.0% R=47.0%; LV; src=wikipedia,online,,,,,,,,,,,,,,,,,
+2026 OH Governor,OH,state,0.4432,1000.0,2025-08-19,Emerson College,D=39.0% R=49.0%; RV; src=wikipedia,mixed,0.355,0.645,0.813,0.116,0.038,0.011,,,0.326,,,,,,,,
+2026 OH Governor,OH,state,0.4432,1000.0,2025-08-22,Emerson College,D=39.0% R=49.0%; LV; src=270towin,mixed,0.355,0.645,0.813,0.116,0.038,0.011,,,0.326,,,,,,,,
+2026 OH Governor,OH,state,0.5055,800.0,2025-09-22,Hart Research (D),D=46.0% R=45.0%; LV; src=wikipedia,phone,,,,,,,,,,,,,,,,,
+2026 OH Governor,OH,state,0.4845,800.0,2025-10-14,YouGov,D=47.0% R=50.0%; RV; src=rcp,online,,,,,,,,,,,,,,,,,
+2026 OH Governor,OH,state,0.4845,800.0,2025-10-14,Bowling Green State University/YouGov,D=47.0% R=50.0%; RV; src=wikipedia,online,,,,,,,,,,,,,,,,,
+2026 OH Governor,OH,state,0.4845,800.0,2025-10-17,Bowling Green Univ.,D=47.0% R=50.0%; RV; src=270towin,online,,,,,,,,,,,,,,,,,
+2026 OH Governor,OH,state,0.5055,850.0,2025-12-08,Emerson College,D=46.0% R=45.0%; RV; src=rcp,mixed,0.355,0.645,0.813,0.116,0.038,0.011,,,0.326,,,,,,,,
+2026 OH Governor,OH,state,0.4886,603.0,2025-12-08,Data Targeting (R),D=43.0% R=45.0%; LV; src=wikipedia,mixed,,,,,,,,,,,,,,,,,
+2026 OH Governor,OH,state,0.5055,850.0,2025-12-11,Emerson College,D=46.0% R=45.0%; RV; src=270towin,mixed,0.355,0.645,0.813,0.116,0.038,0.011,,,0.326,,,,,,,,
+2026 OH Governor,OH,state,0.5521,1343.0,2026-02-22,EMC Research (D),D=53.0% R=43.0%; LV; src=wikipedia,phone,,,,,,,,,,,,,,,,,
+2026 OH Governor,OH,state,0.5521,1343.0,2026-03-10,EMC Research,D=53.0% R=43.0%; LV; src=270towin,phone,,,,,,,,,,,,,,,,,
+2026 OH Governor,OH,state,0.5055,809.0,2026-03-14,Quantus Insights,D=46.0% R=45.0%; LV; src=rcp,online,,,,,,,,,,,,,,,,,
+2026 OH Governor,OH,state,0.5055,809.0,2026-03-16,Quantus Insights,D=46.0% R=45.0%; LV; src=270towin,online,,,,,,,,,,,,,,,,,
+2026 OH Governor,OH,state,0.4947,1000.0,2026-04-14,YouGov,D=47.0% R=48.0%; RV; src=rcp,,,,,,,,,,,,,,,,,,
+2026 OH Governor,OH,state,0.4947,1000.0,2026-04-14,Bowling Green State University/YouGov,D=47.0% R=48.0%; RV; src=wikipedia,,,,,,,,,,,,,,,,,,
+2026 OH Governor,OH,state,0.4947,1000.0,2026-04-20,Bowling Green Univ.,D=47.0% R=48.0%; RV; src=270towin,,,,,,,,,,,,,,,,,,
+2026 OH Governor,OH,state,0.4984,,,Decision Desk HQ,D=45.4% R=45.7%; src=wikipedia,online,,,,,,,,,,,,,,,,,
+2026 OH Senate,OH,state,0.5052,800.0,2025-10-14,YouGov,D=49.0% R=48.0%; RV; src=rcp,online,,,,,,,,,,,,,,,,,
+2026 OH Senate,OH,state,0.4842,850.0,2025-12-08,Emerson College,D=46.0% R=49.0%; RV; src=rcp,mixed,0.355,0.645,0.813,0.116,0.038,0.011,,,0.326,,,,,,,,
+2026 OH Senate,OH,state,0.4889,784.0,2026-03-14,Quantus Insights,D=44.0% R=46.0%; LV; src=rcp,online,,,,,,,,,,,,,,,,,
+2026 OH Senate,OH,state,0.4845,1000.0,2026-04-14,YouGov,D=47.0% R=50.0%; RV; src=rcp,,,,,,,,,,,,,,,,,,
+2026 PA Governor,PA,state,0.5851,1579.0,2025-09-29,Quinnipiac University,D=55.0% R=39.0%; RV; src=wikipedia,phone,,,,,,,,,,,,,,,,,
+2026 PA Governor,PA,state,0.5895,1579.0,2025-10-01,Quinnipiac University,D=56.0% R=39.0%; RV; src=270towin,phone,,,,,,,,,,,,,,,,,
+2026 PA Governor,PA,state,0.5978,836.0,2026-02-23,Quinnipiac University,D=55.0% R=37.0%; RV; src=rcp,phone,,,,,,,,,,,,,,,,,
+2026 PA Governor,PA,state,0.5978,836.0,2026-02-25,Quinnipiac University,D=55.0% R=37.0%; RV; src=270towin,phone,,,,,,,,,,,,,,,,,
+2026 PA Governor,PA,state,0.6316,834.0,2026-03-01,Franklin &amp; Marshall,D=48.0% R=28.0%; RV; src=rcp,phone,,,,,,,,,,,,,,,,,
+2026 PA Governor,PA,state,0.6316,834.0,2026-03-01,Franklin & Marshall College,D=48.0% R=28.0%; RV; src=wikipedia,phone,,,,,,,,,,,,,,,,,
+2026 PA Governor,PA,state,0.6316,834.0,2026-03-05,Franklin & Marshall,D=48.0% R=28.0%; RV; src=270towin,phone,,,,,,,,,,,,,,,,,
+2026 PA Governor,PA,state,0.617,700.0,2026-03-29,Susquehanna,D=58.0% R=36.0%; LV; src=rcp,mixed,,,,,,,,,,,,,,,,,
+2026 TX Governor,TX,state,0.4674,843.0,2025-08-29,Texas Public Opinion Research,D=43.0% R=49.0%; RV; src=wikipedia,phone,,,,,,,,,,,,,,,,,
+2026 TX Governor,TX,state,0.4565,1165.0,2026-01-12,Emerson College,D=42.0% R=50.0%; LV; src=rcp,mixed,0.398,0.602,0.59,0.125,0.223,0.029,,,0.358,,0.345,0.691,0.478,0.518,0.519,0.3415,0.383
+2026 TX Governor,TX,state,0.4565,1165.0,2026-01-15,Emerson College,D=42.0% R=50.0%; LV; src=270towin,mixed,0.398,0.602,0.59,0.125,0.223,0.029,,,0.358,,0.345,0.691,0.478,0.518,0.519,0.3415,0.383
+2026 TX Governor,TX,state,0.4615,1502.0,2026-01-31,University of Houston,D=42.0% R=49.0%; LV; src=rcp,phone,,,,,,,,,,,,,,,,,
+2026 TX Governor,TX,state,0.4615,1502.0,2026-01-31,University of Houston/YouGov,D=42.0% R=49.0%; LV; src=wikipedia,phone,,,,,,,,,,,,,,,,,
+2026 TX Governor,TX,state,0.4831,1000.0,2026-02-03,GBAO (D),D=43.0% R=46.0%; LV; src=wikipedia,phone,,,,,,,,,,,,,,,,,
+2026 TX Governor,TX,state,0.4615,1502.0,2026-02-11,Univ. of Houston,D=42.0% R=49.0%; LV; src=270towin,phone,,,,,,,,,,,,,,,,,
+2026 TX Governor,TX,state,0.4556,1117.0,2026-02-22,UT Tyler,D=41.0% R=49.0%; RV; src=wikipedia,phone,,,,,,,,,,,,,,,,,
+2026 TX Governor,TX,state,0.4556,959.0,2026-02-27,Univ. of Texas - Tyler,D=41.0% R=49.0%; LV; src=270towin,phone,,,,,,,,,,,,,,,,,
+2026 TX Senate,TX,state,0.5,1165.0,2026-01-12,Emerson College,D=46.0% R=46.0%; LV; src=rcp,mixed,0.398,0.602,0.59,0.125,0.223,0.029,,,0.358,,0.345,0.691,0.478,0.518,0.519,0.3415,0.383
+2026 TX Senate,TX,state,0.4889,1502.0,2026-01-31,University of Houston,D=44.0% R=46.0%; LV; src=rcp,phone,,,,,,,,,,,,,,,,,
+2026 WI Governor,WI,state,0.4819,500.0,2025-09-30,Platform Communications,D=40.0% R=43.0%; LV; src=wikipedia,phone,,,,,,,,,,,,,,,,,
+2026 WI Governor,WI,state,0.5319,500.0,2025-10-08,Impact Research (D),D=50.0% R=44.0%; LV; src=wikipedia,online,,,,,,,,,,,,,,,,,
+2026 WI Governor,WI,state,0.5119,1175.0,2026-03-19,TIPP Insights (R),D=43.0% R=41.0%; LV; src=wikipedia,mixed,,,,,,,,,,,,,,,,,
+2026 WI Governor,WI,state,0.4819,1175.0,2026-03-23,TIPP Insights,D=40.0% R=43.0%; LV; src=270towin,mixed,,,,,,,,,,,,,,,,,

--- a/scripts/scrape_2026_polls.py
+++ b/scripts/scrape_2026_polls.py
@@ -1448,23 +1448,45 @@ def main():
         print(df.to_csv(index=False))
     else:
         OUTPUT_PATH.parent.mkdir(parents=True, exist_ok=True)
-        # Merge with existing polls so historical data survives RCP 403s and
-        # scraper gaps. Keep "last" on duplicates — freshly scraped wins.
         if OUTPUT_PATH.exists():
             existing = pd.read_csv(OUTPUT_PATH)
-            merged = pd.concat([existing, df], ignore_index=True).drop_duplicates(
-                subset=["race", "date", "pollster"], keep="last"
-            )
-            merged = merged.sort_values(["race", "date"]).reset_index(drop=True)
-            n_new = len(merged) - len(existing)
-            logger.info(
-                "Merged %d new polls into %d existing → %d total",
-                max(n_new, 0), len(existing), len(merged),
-            )
-            df = merged
+            df = merge_with_existing(df, existing)
         OUTPUT_PATH.parent.mkdir(parents=True, exist_ok=True)
         df.to_csv(OUTPUT_PATH, index=False)
         logger.info("Written %d polls to %s", len(df), OUTPUT_PATH)
+
+
+def merge_with_existing(new: pd.DataFrame, existing: pd.DataFrame) -> pd.DataFrame:
+    """Merge freshly scraped polls with the existing CSV, preserving enrichment.
+
+    Freshly scraped rows win for columns the scraper produces. Enrichment
+    columns (xt_* crosstabs, methodology, etc.) are hand-curated or populated
+    by downstream scripts (scrape_emerson_crosstabs, parse_marist_pdf, ...)
+    and MUST survive a re-scrape of the same race+date+pollster. The naive
+    `concat(...).drop_duplicates(keep="last")` pattern silently overwrites
+    them with NaN, which is the regression fixed here.
+    """
+    key = ["race", "date", "pollster"]
+    enrichment_cols = [c for c in existing.columns if c not in new.columns]
+
+    if enrichment_cols:
+        # Carry enrichment from any matching existing row onto the fresh row.
+        new = new.merge(
+            existing[key + enrichment_cols].drop_duplicates(subset=key, keep="last"),
+            on=key,
+            how="left",
+        )
+
+    merged = pd.concat([existing, new], ignore_index=True).drop_duplicates(
+        subset=key, keep="last"
+    )
+    merged = merged.sort_values(["race", "date"]).reset_index(drop=True)
+    n_new = len(merged) - len(existing)
+    logger.info(
+        "Merged %d new polls into %d existing → %d total",
+        max(n_new, 0), len(existing), len(merged),
+    )
+    return merged
 
 
 if __name__ == "__main__":

--- a/tests/test_scrape_polls.py
+++ b/tests/test_scrape_polls.py
@@ -17,6 +17,7 @@ from scrape_2026_polls import (
     deduplicate,
     extract_pct,
     extract_sample_size,
+    merge_with_existing,
     normalize_pollster,
     parse_poll_date,
     scrape_270towin,
@@ -25,6 +26,8 @@ from scrape_2026_polls import (
     scrape_wikipedia,
     two_party_share,
 )
+
+import pandas as pd
 
 
 # ============================================================================
@@ -1036,3 +1039,131 @@ class TestBuildOutputDfGenericBallot:
         assert gb_row["geography"] == "US"
         assert state_row["geo_level"] == "state"
         assert state_row["geography"] == "GA"
+
+
+# ============================================================================
+# merge_with_existing — preserve xt_* / methodology enrichment on re-scrape
+# ============================================================================
+class TestMergeWithExisting:
+    _SCRAPER_COLS = ["race", "geography", "geo_level", "dem_share",
+                     "n_sample", "date", "pollster", "notes"]
+
+    def _new_row(self, **overrides):
+        base = {
+            "race": "2026 AZ Governor",
+            "geography": "AZ",
+            "geo_level": "state",
+            "dem_share": 0.5057,
+            "n_sample": 850.0,
+            "date": "2025-11-10",
+            "pollster": "Emerson College",
+            "notes": "D=44% R=43%",
+        }
+        base.update(overrides)
+        return base
+
+    def test_rescrape_preserves_xt_enrichment(self):
+        """The regression: xt_* values on an existing row must survive a
+        re-scrape that produces the same race+date+pollster but no xt_*
+        columns. Previously ``drop_duplicates(keep="last")`` wiped them."""
+        existing = pd.DataFrame([
+            {**self._new_row(),
+             "methodology": "mixed",
+             "xt_education_college": 0.355,
+             "xt_race_white": 0.712,
+             "xt_vote_race_white": 0.416},
+        ])
+        new = pd.DataFrame([self._new_row()])
+
+        merged = merge_with_existing(new, existing)
+
+        assert len(merged) == 1
+        row = merged.iloc[0]
+        assert row["xt_education_college"] == 0.355
+        assert row["xt_race_white"] == 0.712
+        assert row["xt_vote_race_white"] == 0.416
+        assert row["methodology"] == "mixed"
+
+    def test_rescrape_prefers_fresh_scraper_cols(self):
+        """Scraper-produced columns (dem_share, n_sample, notes) on the
+        fresh row win over the stale existing values."""
+        existing = pd.DataFrame([
+            {**self._new_row(dem_share=0.47, n_sample=800, notes="stale"),
+             "xt_education_college": 0.355},
+        ])
+        new = pd.DataFrame([
+            self._new_row(dem_share=0.5057, n_sample=850, notes="fresh"),
+        ])
+
+        merged = merge_with_existing(new, existing)
+
+        assert len(merged) == 1
+        row = merged.iloc[0]
+        assert row["dem_share"] == 0.5057
+        assert row["n_sample"] == 850
+        assert row["notes"] == "fresh"
+        # enrichment still preserved
+        assert row["xt_education_college"] == 0.355
+
+    def test_new_row_has_no_existing_match(self):
+        """A brand-new race+date+pollster triple is appended, not merged."""
+        existing = pd.DataFrame([
+            {**self._new_row(race="2026 OH Governor", geography="OH"),
+             "xt_education_college": 0.40},
+        ])
+        new = pd.DataFrame([self._new_row()])
+
+        merged = merge_with_existing(new, existing)
+
+        assert len(merged) == 2
+        az = merged[merged["race"] == "2026 AZ Governor"].iloc[0]
+        oh = merged[merged["race"] == "2026 OH Governor"].iloc[0]
+        # New row gets NaN for enrichment columns (nothing to carry)
+        assert pd.isna(az["xt_education_college"])
+        # Existing row keeps its enrichment
+        assert oh["xt_education_college"] == 0.40
+
+    def test_existing_row_with_no_fresh_match_is_preserved(self):
+        """Polls in the existing CSV that weren't re-scraped (e.g. because
+        RCP returned 403) must survive the merge unchanged."""
+        existing = pd.DataFrame([
+            {**self._new_row(race="2026 OH Governor", geography="OH",
+                             dem_share=0.45),
+             "xt_education_college": 0.40},
+        ])
+        new = pd.DataFrame([self._new_row()])  # different race entirely
+
+        merged = merge_with_existing(new, existing)
+
+        oh_rows = merged[merged["race"] == "2026 OH Governor"]
+        assert len(oh_rows) == 1
+        assert oh_rows.iloc[0]["dem_share"] == 0.45
+        assert oh_rows.iloc[0]["xt_education_college"] == 0.40
+
+    def test_no_enrichment_cols_behaves_like_plain_dedup(self):
+        """When the existing CSV has no extra columns, merge collapses to
+        the original concat+drop_duplicates semantics."""
+        existing = pd.DataFrame([
+            self._new_row(dem_share=0.47, notes="old"),
+        ])
+        new = pd.DataFrame([self._new_row(dem_share=0.5057, notes="new")])
+
+        merged = merge_with_existing(new, existing)
+
+        assert len(merged) == 1
+        assert merged.iloc[0]["dem_share"] == 0.5057
+        assert merged.iloc[0]["notes"] == "new"
+
+    def test_duplicate_existing_rows_deduped_by_last(self):
+        """If the existing CSV has duplicates on the key (shouldn't happen
+        but could from hand-edits), the last-seen enrichment is used."""
+        existing = pd.DataFrame([
+            {**self._new_row(notes="first"), "xt_education_college": 0.30},
+            {**self._new_row(notes="second"), "xt_education_college": 0.35},
+        ])
+        new = pd.DataFrame([self._new_row(notes="fresh")])
+
+        merged = merge_with_existing(new, existing)
+
+        assert len(merged) == 1
+        assert merged.iloc[0]["xt_education_college"] == 0.35


### PR DESCRIPTION
## Summary

- Poll scraper's `concat(...).drop_duplicates(keep="last")` merge silently wiped `xt_*` crosstab and `methodology` columns on any re-scraped row — because the fresh-scraped `df` has no such columns, the kept row got NaN for every enrichment field that Tier 2 W-vector construction depends on. Commit 47d23b9 (S497 refresh) is where the data was first lost; fa7ead6 added the merge but didn't close this gap.
- Fix extracts merge into `merge_with_existing()` that left-joins enrichment columns from the existing row onto the fresh row before dedup — scraper columns (`dem_share`, `n_sample`, `notes`) still prefer the fresh value, while `xt_*` / `methodology` survive.
- Restores the lost enrichment data from the pre-regression commit (47d23b9^) for 201 matching `(race, date, pollster)` rows: 25 polls regain crosstab composition, 20 regain per-group vote shares, 201 regain methodology tags.

Closes the crosstab-W-vector item in #94.

## Test plan

- [x] 6 new `TestMergeWithExisting` cases cover the regression, fresh-wins-on-shared-columns, append semantics for brand-new polls, existing-preserved-when-unscraped, no-enrichment-cols passthrough, and duplicate-key handling
- [x] Full suite: 4388 passed, 21 skipped in 153s

🤖 Generated with [Claude Code](https://claude.com/claude-code)