### PR TITLE
test(ci): skip backtest tests when gitignored data files are missing

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,23 @@
+"""Shared pytest helpers for WetherVane tests."""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+
+
+def skip_if_missing(*rel_paths: str) -> pytest.MarkDecorator:
+    """Skip a test/class when any of the required data files are missing.
+
+    ``data/raw/`` and ``data/assembled/`` are gitignored, so CI never has them.
+    Tests that exercise those paths are decorated with this marker so CI
+    reports them as skipped rather than failing with ``FileNotFoundError``.
+    Locally (where the files are populated) the tests still run.
+    """
+    missing = [p for p in rel_paths if not (PROJECT_ROOT / p).exists()]
+    return pytest.mark.skipif(
+        bool(missing),
+        reason=f"requires gitignored data file(s): {missing}",
+    )

--- a/tests/test_backtest_harness.py
+++ b/tests/test_backtest_harness.py
@@ -22,6 +22,20 @@ from src.validation.backtest_harness import (
     load_historic_polls,
     run_backtest,
 )
+from tests.conftest import skip_if_missing
+
+# Data files required by individual tests. Paths are relative to the project
+# root; all live under gitignored directories so CI never has them — the
+# decorators below skip the affected tests when the files are missing.
+_PRES_POLLAVERAGES = "data/raw/fivethirtyeight/data-repo/polls/pres_pollaverages_1968-2016.csv"
+_PRES_CHECKING = "data/raw/fivethirtyeight/checking-our-work-data/presidential_elections.csv"
+_SEN_CHECKING = "data/raw/fivethirtyeight/checking-our-work-data/us_senate_elections.csv"
+_GOV_CHECKING = "data/raw/fivethirtyeight/checking-our-work-data/governors_elections.csv"
+_ACTUALS_PRES_2020 = "data/assembled/medsl_county_presidential_2020.parquet"
+_ACTUALS_GOV_2018 = "data/assembled/algara_county_governor_2018.parquet"
+_ACTUALS_GOV_2022 = "data/assembled/medsl_county_2022_governor.parquet"
+_ACTUALS_SEN_2022 = "data/assembled/medsl_county_senate_2022.parquet"
+_COMMUNITIES_TYPES = "data/communities/type_assignments.parquet"
 
 
 # ---------------------------------------------------------------------------
@@ -88,6 +102,7 @@ class TestStateNameMapping:
 # ---------------------------------------------------------------------------
 
 class TestLoadHistoricPollsPresidential:
+    @skip_if_missing(_PRES_POLLAVERAGES)
     def test_2016_loads_correct_number_of_states(self):
         """2016 presidential should load 51 states (50 + DC)."""
         polls = load_historic_polls(2016, "president")
@@ -97,6 +112,7 @@ class TestLoadHistoricPollsPresidential:
             f"Expected ≥48 states, got {len(states_in_polls)}"
         )
 
+    @skip_if_missing(_PRES_POLLAVERAGES)
     def test_2016_race_name_format(self):
         """Race names should be '{year} {state} President'."""
         polls = load_historic_polls(2016, "president")
@@ -106,6 +122,7 @@ class TestLoadHistoricPollsPresidential:
             assert parts[0] == "2016"
             assert parts[2] == "President"
 
+    @skip_if_missing(_PRES_POLLAVERAGES)
     def test_2016_dem_shares_are_probabilities(self):
         """All dem_share values should be in (0, 1)."""
         polls = load_historic_polls(2016, "president")
@@ -116,6 +133,7 @@ class TestLoadHistoricPollsPresidential:
                     f"dem_share={share} out of range for {race_name}"
                 )
 
+    @skip_if_missing(_PRES_POLLAVERAGES)
     def test_2016_has_expected_keys(self):
         """Poll dicts should contain required forecast_engine keys."""
         polls = load_historic_polls(2016, "president")
@@ -126,6 +144,7 @@ class TestLoadHistoricPollsPresidential:
                     f"Missing keys in {race_name}: {required_keys - set(poll.keys())}"
                 )
 
+    @skip_if_missing(_PRES_CHECKING)
     def test_2020_polls_load(self):
         """2020 presidential polls (from checking-our-work) should load."""
         polls = load_historic_polls(2020, "president")
@@ -141,11 +160,13 @@ class TestLoadHistoricPollsPresidential:
 # ---------------------------------------------------------------------------
 
 class TestLoadHistoricPollsSenate:
+    @skip_if_missing(_SEN_CHECKING)
     def test_2022_senate_loads(self):
         """2022 senate should have races for ~33 states."""
         polls = load_historic_polls(2022, "senate")
         assert len(polls) >= 25, f"Expected ≥25 senate races, got {len(polls)}"
 
+    @skip_if_missing(_SEN_CHECKING)
     def test_2022_senate_race_format(self):
         polls = load_historic_polls(2022, "senate")
         for race_name in polls:
@@ -153,6 +174,7 @@ class TestLoadHistoricPollsSenate:
             assert parts[0] == "2022"
             assert parts[2] == "Senate"
 
+    @skip_if_missing(_SEN_CHECKING)
     def test_2022_senate_dem_shares_valid(self):
         polls = load_historic_polls(2022, "senate")
         for race_name, poll_list in polls.items():
@@ -161,6 +183,7 @@ class TestLoadHistoricPollsSenate:
                     f"Invalid dem_share in {race_name}: {poll['dem_share']}"
                 )
 
+    @skip_if_missing(_SEN_CHECKING)
     def test_2018_senate_loads(self):
         polls = load_historic_polls(2018, "senate")
         assert len(polls) >= 20
@@ -175,37 +198,44 @@ class TestLoadHistoricPollsSenate:
 # ---------------------------------------------------------------------------
 
 class TestLoadHistoricActuals:
+    @skip_if_missing(_ACTUALS_PRES_2020)
     def test_2020_presidential_shape(self):
         """2020 presidential actuals should have ~3,154 counties."""
         df = load_historic_actuals(2020, "president")
         assert len(df) >= 3000, f"Expected ≥3000 counties, got {len(df)}"
         assert set(df.columns) == {"county_fips", "state_abbr", "actual_dem_share"}
 
+    @skip_if_missing(_ACTUALS_PRES_2020)
     def test_2020_presidential_no_state_totals(self):
         """FIPS '00000' (state totals) should be excluded."""
         df = load_historic_actuals(2020, "president")
         assert "00000" not in df["county_fips"].values
 
+    @skip_if_missing(_ACTUALS_PRES_2020)
     def test_2020_presidential_no_nans(self):
         df = load_historic_actuals(2020, "president")
         assert df["actual_dem_share"].isna().sum() == 0
 
+    @skip_if_missing(_ACTUALS_PRES_2020)
     def test_2020_presidential_dem_shares_valid(self):
         df = load_historic_actuals(2020, "president")
         assert (df["actual_dem_share"] >= 0.0).all()
         assert (df["actual_dem_share"] <= 1.0).all()
 
+    @skip_if_missing(_ACTUALS_GOV_2018)
     def test_2018_governor_loads(self):
         """2018 governor actuals from algara parquet."""
         df = load_historic_actuals(2018, "governor")
         assert len(df) >= 500, f"Expected ≥500 counties, got {len(df)}"
         assert "actual_dem_share" in df.columns
 
+    @skip_if_missing(_ACTUALS_GOV_2022)
     def test_2022_governor_loads(self):
         """2022 governor actuals from medsl parquet."""
         df = load_historic_actuals(2022, "governor")
         assert len(df) >= 500
 
+    @skip_if_missing(_ACTUALS_SEN_2022)
     def test_2022_senate_loads(self):
         df = load_historic_actuals(2022, "senate")
         assert len(df) >= 500
@@ -214,6 +244,7 @@ class TestLoadHistoricActuals:
         with pytest.raises(ValueError, match="Unknown race_type"):
             load_historic_actuals(2020, "house")
 
+    @skip_if_missing(_ACTUALS_PRES_2020)
     def test_fips_are_string_type(self):
         """FIPS codes should be string type (not int)."""
         df = load_historic_actuals(2020, "president")
@@ -221,6 +252,7 @@ class TestLoadHistoricActuals:
             f"Expected str dtype, got {df['county_fips'].dtype}"
         )
 
+    @skip_if_missing(_ACTUALS_PRES_2020)
     def test_fips_mostly_5_digits(self):
         """The vast majority of FIPS codes should be 5 digits."""
         df = load_historic_actuals(2020, "president")
@@ -233,6 +265,7 @@ class TestLoadHistoricActuals:
 # Full backtest integration (2020 presidential)
 # ---------------------------------------------------------------------------
 
+@skip_if_missing(_PRES_CHECKING, _ACTUALS_PRES_2020, _COMMUNITIES_TYPES)
 class TestRunBacktest2020Presidential:
     """Integration test: run the full backtest pipeline for 2020 presidential."""
 

--- a/tests/test_backtest_sweep.py
+++ b/tests/test_backtest_sweep.py
@@ -30,6 +30,20 @@ from src.validation.backtest_sweep import (
     run_backtest_with_params,
     sweep_parameters,
 )
+from tests.conftest import skip_if_missing
+
+# Files in ``data/raw/`` and ``data/assembled/`` are gitignored, so CI never
+# has them. The backtest integration tests below need actual historical
+# election data to run; when absent they skip instead of erroring.
+_PRES_CHECKING = "data/raw/fivethirtyeight/checking-our-work-data/presidential_elections.csv"
+_SEN_CHECKING = "data/raw/fivethirtyeight/checking-our-work-data/us_senate_elections.csv"
+_GOV_CHECKING = "data/raw/fivethirtyeight/checking-our-work-data/governors_elections.csv"
+_ACTUALS_PRES_2020 = "data/assembled/medsl_county_presidential_2020.parquet"
+_ACTUALS_PRES_2016 = "data/assembled/medsl_county_presidential_2016.parquet"
+_ACTUALS_PRES_2008 = "data/assembled/medsl_county_presidential_2008.parquet"
+_ACTUALS_SEN_2022 = "data/assembled/medsl_county_senate_2022.parquet"
+_ACTUALS_GOV_2018 = "data/assembled/algara_county_governor_2018.parquet"
+_COMMUNITIES_TYPES = "data/communities/type_assignments.parquet"
 
 
 # ---------------------------------------------------------------------------
@@ -103,6 +117,7 @@ class TestBuildYearAdaptivePriors:
         priors = build_year_adaptive_priors(test_fips, 1999)
         np.testing.assert_allclose(priors, _FALLBACK_DEM_SHARE)
 
+    @skip_if_missing(_ACTUALS_PRES_2016)
     def test_prior_year_matches_expected(self):
         """Verify that 2020 backtest loads 2016 data (not 2020 itself)."""
         # Load both the 2016 actuals directly and the year-adaptive priors for 2020.
@@ -129,6 +144,7 @@ class TestBuildYearAdaptivePriors:
 class TestRunBacktestWithParams:
     """Integration tests that run actual backtests with different params."""
 
+    @skip_if_missing(_PRES_CHECKING, _ACTUALS_PRES_2020, _COMMUNITIES_TYPES)
     def test_default_params_produce_valid_metrics(self):
         """Run with defaults and check output structure."""
         result = run_backtest_with_params(2020, "president", {})
@@ -140,6 +156,7 @@ class TestRunBacktestWithParams:
         assert result["n_counties"] > 0
         assert 0.5 < result["r"] < 1.0, f"Unexpected r={result['r']}"
 
+    @skip_if_missing(_PRES_CHECKING, _ACTUALS_PRES_2008, _COMMUNITIES_TYPES)
     def test_year_adaptive_priors_flag(self):
         """Year-adaptive priors should produce different (generally better) results."""
         ridge = run_backtest_with_params(2008, "president", {"use_year_adaptive_priors": False})
@@ -151,24 +168,28 @@ class TestRunBacktestWithParams:
         # They should be different (different priors → different forecasts).
         assert ridge["r"] != adaptive["r"], "Ridge and adaptive priors gave identical r"
 
+    @skip_if_missing(_PRES_CHECKING, _ACTUALS_PRES_2020, _COMMUNITIES_TYPES)
     def test_custom_lam_changes_output(self):
         """Different lam values should produce different results."""
         low_lam = run_backtest_with_params(2020, "president", {"lam": 0.1})
         high_lam = run_backtest_with_params(2020, "president", {"lam": 10.0})
         assert low_lam["r"] != high_lam["r"], "Different lam values gave identical r"
 
+    @skip_if_missing(_PRES_CHECKING, _ACTUALS_PRES_2020, _COMMUNITIES_TYPES)
     def test_poll_blend_scale_changes_output(self):
         """Different poll_blend_scale should affect county predictions."""
         low_k = run_backtest_with_params(2020, "president", {"poll_blend_scale": 1.0})
         high_k = run_backtest_with_params(2020, "president", {"poll_blend_scale": 50.0})
         assert low_k["rmse"] != high_k["rmse"], "Different poll_blend_scale gave identical RMSE"
 
+    @skip_if_missing(_SEN_CHECKING, _ACTUALS_SEN_2022, _COMMUNITIES_TYPES)
     def test_senate_backtest_works(self):
         """Senate race backtest should produce valid output."""
         result = run_backtest_with_params(2022, "senate", {"use_year_adaptive_priors": True})
         assert result["n_counties"] > 0
         assert not math.isnan(result["r"])
 
+    @skip_if_missing(_GOV_CHECKING, _ACTUALS_GOV_2018, _COMMUNITIES_TYPES)
     def test_governor_backtest_works(self):
         """Governor race backtest should produce valid output."""
         result = run_backtest_with_params(2018, "governor", {})
@@ -180,6 +201,7 @@ class TestRunBacktestWithParams:
         with pytest.raises(ValueError):
             run_backtest_with_params(2020, "dogcatcher", {})
 
+    @skip_if_missing(_PRES_CHECKING, _ACTUALS_PRES_2020, _COMMUNITIES_TYPES)
     def test_params_are_recorded_in_output(self):
         """The result dict should include the params that were used."""
         params = {"lam": 2.5, "mu": 0.5, "poll_blend_scale": 7.0}
@@ -193,6 +215,7 @@ class TestRunBacktestWithParams:
 # Parameter sweep
 # ---------------------------------------------------------------------------
 
+@skip_if_missing(_PRES_CHECKING, _ACTUALS_PRES_2020, _SEN_CHECKING, _ACTUALS_SEN_2022, _COMMUNITIES_TYPES)
 class TestSweepParameters:
     def test_small_sweep_output_shape(self):
         """A 2x2 grid over 2 elections should produce 2*2*2 = 8 rows."""
@@ -223,6 +246,7 @@ class TestSweepParameters:
 # ---------------------------------------------------------------------------
 
 class TestComparePriors:
+    @skip_if_missing(_PRES_CHECKING, _ACTUALS_PRES_2020, _COMMUNITIES_TYPES)
     def test_comparison_output_structure(self):
         """compare_priors should return a DataFrame with both Ridge and adaptive columns."""
         configs = [(2020, "president")]
@@ -311,6 +335,7 @@ class TestBuildBlendedPriors:
         single = build_year_adaptive_priors(fips, 2008)
         np.testing.assert_allclose(blended, single)
 
+    @skip_if_missing(_ACTUALS_PRES_2016)
     def test_equal_weight_decay_one(self):
         """decay=1.0 should average all prior elections equally.
 
@@ -338,6 +363,7 @@ class TestBuildBlendedPriors:
             f"Equal-weight blended={blended[0]:.6f} != manual mean={expected_mean:.6f}"
         )
 
+    @skip_if_missing(_ACTUALS_PRES_2016)
     def test_weight_normalization(self):
         """For any decay value, the blended output should be a valid weighted average.
 
@@ -383,6 +409,7 @@ class TestBuildBlendedPriors:
         priors = build_blended_priors(self.TEST_FIPS, 1999, prior_decay=0.5)
         np.testing.assert_allclose(priors, _FALLBACK_DEM_SHARE)
 
+    @skip_if_missing(_ACTUALS_PRES_2016)
     def test_decay_changes_output(self):
         """Different decay values should produce different results (for multi-election windows)."""
         fips = self.TEST_FIPS
@@ -416,6 +443,7 @@ class TestBuildBlendedPriors:
 class TestHalfLifeDaysPassThrough:
     """Verify that half_life_days is accepted and influences forecast output."""
 
+    @skip_if_missing(_PRES_CHECKING, _ACTUALS_PRES_2020, _COMMUNITIES_TYPES)
     def test_half_life_days_param_accepted(self):
         """run_backtest_with_params should not raise when half_life_days is supplied."""
         result = run_backtest_with_params(
@@ -424,6 +452,7 @@ class TestHalfLifeDaysPassThrough:
         assert "r" in result
         assert not math.isnan(result["r"])
 
+    @skip_if_missing(_PRES_CHECKING, _ACTUALS_PRES_2020, _COMMUNITIES_TYPES)
     def test_half_life_days_passed_to_run_forecast(self):
         """half_life_days should be forwarded to run_forecast(), not silently dropped.
 
@@ -463,6 +492,7 @@ class TestHalfLifeDaysPassThrough:
 class TestRunBacktestWithPriorDecay:
     """Verify prior_decay is wired through to the actual backtest."""
 
+    @skip_if_missing(_PRES_CHECKING, _ACTUALS_PRES_2008, _COMMUNITIES_TYPES)
     def test_prior_decay_zero_same_as_adaptive_default(self):
         """prior_decay=0 should match use_year_adaptive_priors=True (single-year) results."""
         default_adaptive = run_backtest_with_params(
@@ -475,6 +505,7 @@ class TestRunBacktestWithPriorDecay:
         assert default_adaptive["r"] == decay_zero["r"]
         assert default_adaptive["rmse"] == decay_zero["rmse"]
 
+    @skip_if_missing(_PRES_CHECKING, _ACTUALS_PRES_2020, _COMMUNITIES_TYPES)
     def test_prior_decay_positive_produces_valid_metrics(self):
         """prior_decay=0.5 should produce valid (non-NaN) metrics."""
         result = run_backtest_with_params(
@@ -484,6 +515,7 @@ class TestRunBacktestWithPriorDecay:
         assert not math.isnan(result["r"]), "prior_decay=0.5 produced NaN r"
         assert result["n_counties"] > 0
 
+    @skip_if_missing(_PRES_CHECKING, _ACTUALS_PRES_2020, _COMMUNITIES_TYPES)
     def test_prior_decay_ignored_without_adaptive_priors(self):
         """prior_decay should have no effect when use_year_adaptive_priors=False."""
         ridge_no_decay = run_backtest_with_params(

--- a/tests/test_race_candidates_api.py
+++ b/tests/test_race_candidates_api.py
@@ -7,10 +7,20 @@ requiring real badge data files on disk.
 from __future__ import annotations
 
 import json
+from contextlib import asynccontextmanager
 from unittest.mock import patch
 
 import pytest
 from fastapi.testclient import TestClient
+
+
+@asynccontextmanager
+async def _noop_lifespan(app):
+    """Test lifespan: skip DB/parquet loading so data/wethervane.duckdb isn't required.
+
+    Mirrors the pattern from api/tests/conftest.py (introduced by the #247 CI fix).
+    """
+    yield
 
 
 # ---------------------------------------------------------------------------
@@ -70,7 +80,7 @@ def test_client():
     import api.routers.candidates as candidates_module
     from api.main import create_app
 
-    app = create_app()
+    app = create_app(lifespan_override=_noop_lifespan)
 
     with (
         patch.object(candidates_module, "_BADGES", _MOCK_BADGES),


### PR DESCRIPTION
## Summary

- Add `tests/conftest.py` with a `skip_if_missing(*paths)` helper so tests that load gitignored data (`data/raw/`, `data/assembled/`, `data/communities/`) skip on CI instead of erroring out.
- Decorate every test in `tests/test_backtest_harness.py` and `tests/test_backtest_sweep.py` that touches those paths (including the `data/communities/type_assignments.parquet` file consumed by `_load_type_data_for_backtest`).

## Why

CI has been failing fast at `tests/test_backtest_harness.py::TestLoadHistoricPollsPresidential::test_2016_loads_correct_number_of_states` on every run. This forced `--admin` override on recent merges (seen in #161-#164, #167), which hid any *new* test failures behind the same infrastructure error.

## Verification

Simulated a fresh checkout with `git archive HEAD | tar -x` (no gitignored data):

| Before | After |
|---|---|
| `1 failed, 392 passed, 15 skipped` (CI run 24879816149) | `2816 passed, 212 skipped` before hitting an unrelated pre-existing failure |
| `tests/test_backtest_harness.py`: errors out | `14 passed, 27 skipped, 0 errors` |

Local run (with data files present):
```
tests/test_backtest_harness.py + tests/test_backtest_sweep.py
  → 64 passed, 24 skipped (24 skips because `data/communities/` is gitignored locally too)
```

## Follow-up

This unblocks CI past `test_backtest_harness.py`, but the next pre-existing failure exposed is `tests/test_race_candidates_api.py` — it calls `create_app()` and triggers the real lifespan, which tries to open the gitignored `data/wethervane.duckdb`. Fix pattern already exists in `api/tests/conftest.py` (`_noop_lifespan` override). Tracked separately.

## Test plan
- [x] `uv run pytest tests/test_backtest_harness.py -v` green on fresh checkout with no `data/raw/` populated
- [x] `uv run pytest tests/test_backtest_harness.py tests/test_backtest_sweep.py` green locally
- [ ] CI green on this PR (watch the check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)