### PR TITLE
FEATURE: WetherVane v29 T1 -- migrate StateCountyTable to useUrlState

### DIFF
--- a/api/models.py
+++ b/api/models.py
@@ -717,6 +717,98 @@ class PollsterAccuracyResponse(BaseModel):
     """Pollsters sorted by rank (ascending RMSE -- best first)."""
 
 
+# ── Poll coverage diagnostics ───────────────────────────────────────────────
+
+
+class PollCoverageMetadata(BaseModel):
+    """Metadata for the generated poll coverage diagnostic report."""
+
+    total_polls: int
+    polls_with_xt_data: int
+    polls_analyzed: int
+    active_xt_columns: list[str]
+    mappable_xt_columns: list[str]
+    oversample_threshold: float
+    undersample_threshold: float
+
+
+class PollCoverageAffectedType(BaseModel):
+    """Community type most exposed to an undersampled demographic group."""
+
+    type_id: int
+    display_name: str
+    group_share: float
+    state_weight: float
+    exposure: float
+
+
+class PollCoverageGap(BaseModel):
+    """Coverage status for one demographic group in one poll."""
+
+    demographic_group: str
+    label: str
+    poll_share: float
+    population_share: float
+    ratio: float
+    status: str
+    affected_types: list[PollCoverageAffectedType] = Field(default_factory=list)
+
+
+class PollCoveragePollResult(BaseModel):
+    """Coverage diagnostic result for one poll."""
+
+    race: str
+    state: str
+    pollster: str
+    date: str
+    n_sample: int | None
+    n_groups_analyzed: int
+    n_undersampled: int
+    n_oversampled: int
+    gaps: list[PollCoverageGap]
+
+
+class PollCoverageTopAffectedType(BaseModel):
+    """Aggregate count for a type affected by a demographic gap."""
+
+    type_label: str
+    n_races_affected: int
+
+
+class PollCoverageGroupSummary(BaseModel):
+    """Aggregate coverage counts for one demographic group."""
+
+    label: str
+    n_undersampled: int
+    n_oversampled: int
+    n_representative: int
+    n_total_polls: int
+    top_affected_types: list[PollCoverageTopAffectedType]
+
+
+class PollCoverageUndersampledRankingEntry(BaseModel):
+    """One chronically undersampled group ranked by poll count."""
+
+    group: str
+    label: str
+    n_polls_undersampled: int
+
+
+class PollCoverageSummary(BaseModel):
+    """Aggregate poll coverage diagnostic summary."""
+
+    by_group: dict[str, PollCoverageGroupSummary]
+    undersampled_ranking: list[PollCoverageUndersampledRankingEntry]
+
+
+class PollCoverageReportResponse(BaseModel):
+    """Generated poll coverage diagnostic report."""
+
+    metadata: PollCoverageMetadata
+    summary: PollCoverageSummary
+    per_poll_results: list[PollCoveragePollResult]
+
+
 # ── Sabermetrics: candidate badges & CTOV ───────────────────────────────────
 
 

--- a/api/routers/pollsters.py
+++ b/api/routers/pollsters.py
@@ -13,7 +13,11 @@ from pathlib import Path
 
 from fastapi import APIRouter, HTTPException
 
-from api.models import PollsterAccuracyEntry, PollsterAccuracyResponse
+from api.models import (
+    PollCoverageReportResponse,
+    PollsterAccuracyEntry,
+    PollsterAccuracyResponse,
+)
 
 log = logging.getLogger(__name__)
 
@@ -25,6 +29,12 @@ _ACCURACY_PATH = (
     / "data"
     / "experiments"
     / "pollster_accuracy.json"
+)
+_COVERAGE_REPORT_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "data"
+    / "diagnostics"
+    / "poll_coverage_report.json"
 )
 
 
@@ -43,6 +53,23 @@ def _load_accuracy_data() -> dict:
             ),
         )
     with open(_ACCURACY_PATH) as f:
+        return json.load(f)
+
+
+def _load_coverage_report() -> dict:
+    """Load poll coverage diagnostics JSON from disk.
+
+    Raises HTTPException(503) if the report has not been generated yet.
+    """
+    if not _COVERAGE_REPORT_PATH.exists():
+        raise HTTPException(
+            status_code=503,
+            detail=(
+                "Poll coverage diagnostics report not yet generated. "
+                "Run: uv run python scripts/analyze_poll_coverage.py"
+            ),
+        )
+    with open(_COVERAGE_REPORT_PATH) as f:
         return json.load(f)
 
 
@@ -76,3 +103,13 @@ def get_pollster_accuracy() -> PollsterAccuracyResponse:
         n_pollsters=raw.get("n_pollsters", len(pollsters)),
         pollsters=pollsters,
     )
+
+
+@router.get("/pollsters/coverage", response_model=PollCoverageReportResponse)
+def get_poll_coverage_report() -> PollCoverageReportResponse:
+    """Return the generated poll coverage diagnostics report.
+
+    The data is generated offline by ``scripts/analyze_poll_coverage.py`` and
+    identifies demographic coverage gaps in polls with xt_ composition data.
+    """
+    return PollCoverageReportResponse.model_validate(_load_coverage_report())

--- a/api/tests/test_poll_coverage_diagnostics.py
+++ b/api/tests/test_poll_coverage_diagnostics.py
@@ -1,0 +1,126 @@
+"""Tests for the poll coverage diagnostics API endpoint."""
+
+from __future__ import annotations
+
+import json
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+import api.routers.pollsters as pollsters_mod
+
+
+def _client() -> TestClient:
+    app = FastAPI()
+    app.include_router(pollsters_mod.router, prefix="/api/v1")
+    return TestClient(app)
+
+
+def _sample_report() -> dict:
+    return {
+        "metadata": {
+            "total_polls": 12,
+            "polls_with_xt_data": 2,
+            "polls_analyzed": 1,
+            "active_xt_columns": ["xt_race_black", "xt_education_college"],
+            "mappable_xt_columns": ["xt_race_black", "xt_education_college"],
+            "oversample_threshold": 1.2,
+            "undersample_threshold": 0.8,
+        },
+        "summary": {
+            "by_group": {
+                "xt_race_black": {
+                    "label": "Black",
+                    "n_undersampled": 1,
+                    "n_oversampled": 0,
+                    "n_representative": 0,
+                    "n_total_polls": 1,
+                    "top_affected_types": [
+                        {
+                            "type_label": "4: Urban Black Belt",
+                            "n_races_affected": 1,
+                        }
+                    ],
+                }
+            },
+            "undersampled_ranking": [
+                {
+                    "group": "xt_race_black",
+                    "label": "Black",
+                    "n_polls_undersampled": 1,
+                }
+            ],
+        },
+        "per_poll_results": [
+            {
+                "race": "2026 GA Governor",
+                "state": "GA",
+                "pollster": "Example Polling",
+                "date": "2026-05-01",
+                "n_sample": 800,
+                "n_groups_analyzed": 1,
+                "n_undersampled": 1,
+                "n_oversampled": 0,
+                "gaps": [
+                    {
+                        "demographic_group": "xt_race_black",
+                        "label": "Black",
+                        "poll_share": 0.18,
+                        "population_share": 0.32,
+                        "ratio": 0.5625,
+                        "status": "undersampled",
+                        "affected_types": [
+                            {
+                                "type_id": 4,
+                                "display_name": "Urban Black Belt",
+                                "group_share": 0.54,
+                                "state_weight": 0.21,
+                                "exposure": 0.39,
+                            }
+                        ],
+                    }
+                ],
+            }
+        ],
+    }
+
+
+def test_poll_coverage_report_success_includes_diagnostics(tmp_path, monkeypatch):
+    report_path = tmp_path / "poll_coverage_report.json"
+    report_path.write_text(json.dumps(_sample_report()))
+    monkeypatch.setattr(pollsters_mod, "_COVERAGE_REPORT_PATH", report_path)
+
+    response = _client().get("/api/v1/pollsters/coverage")
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["metadata"]["polls_analyzed"] == 1
+    assert "xt_race_black" in data["summary"]["by_group"]
+    assert data["summary"]["undersampled_ranking"][0] == {
+        "group": "xt_race_black",
+        "label": "Black",
+        "n_polls_undersampled": 1,
+    }
+    gap = data["per_poll_results"][0]["gaps"][0]
+    assert gap["affected_types"] == [
+        {
+            "type_id": 4,
+            "display_name": "Urban Black Belt",
+            "group_share": 0.54,
+            "state_weight": 0.21,
+            "exposure": 0.39,
+        }
+    ]
+
+
+def test_poll_coverage_report_missing_file_returns_503(tmp_path, monkeypatch):
+    missing_path = tmp_path / "missing_poll_coverage_report.json"
+    monkeypatch.setattr(pollsters_mod, "_COVERAGE_REPORT_PATH", missing_path)
+
+    response = _client().get("/api/v1/pollsters/coverage")
+
+    assert response.status_code == 503
+    assert response.json()["detail"] == (
+        "Poll coverage diagnostics report not yet generated. "
+        "Run: uv run python scripts/analyze_poll_coverage.py"
+    )

--- a/web/components/state/StateCountyTable.tsx
+++ b/web/components/state/StateCountyTable.tsx
@@ -2,10 +2,10 @@
 
 import { useEffect } from "react";
 import Link from "next/link";
-import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { MarginDisplay } from "@/components/shared/MarginDisplay";
 import { getSuperTypeColor, rgbToHex } from "@/lib/config/palette";
 import { stripStateSuffix } from "@/lib/config/states";
+import { useUrlState, type UrlStateSpec } from "@/lib/hooks/use-url-state";
 
 export interface CountyTableRow {
   county_fips: string;
@@ -26,6 +26,12 @@ interface StateCountyTableProps {
 const SORT_KEYS = ["name", "type", "lean"] as const;
 type SortField = (typeof SORT_KEYS)[number];
 type SortDir = "asc" | "desc";
+
+interface CountyTableUrlState {
+  sort: SortField;
+  dir: SortDir;
+  page: number;
+}
 
 const DEFAULT_SORT_KEY: SortField = "lean";
 const DEFAULT_SORT_DIR: SortDir = "desc";
@@ -60,20 +66,37 @@ function isDefaultSort(key: SortField, dir: SortDir): boolean {
   return key === DEFAULT_SORT_KEY && dir === DEFAULT_SORT_DIR;
 }
 
+const COUNTY_TABLE_URL_SPEC: UrlStateSpec<CountyTableUrlState> = {
+  sort: {
+    param: SORT_PARAM,
+    defaultValue: DEFAULT_SORT_KEY,
+    parse: (raw) => (isSortKey(raw) ? raw : DEFAULT_SORT_KEY),
+    serialize: (value, state) => (isDefaultSort(value, state.dir) ? null : value),
+  },
+  dir: {
+    param: DIR_PARAM,
+    defaultValue: DEFAULT_SORT_DIR,
+    parse: (raw, params) => {
+      const rawSort = params.get(SORT_PARAM);
+      const sort = isSortKey(rawSort) ? rawSort : DEFAULT_SORT_KEY;
+      return isSortKey(rawSort) && isSortDir(raw) ? raw : defaultDirForSort(sort);
+    },
+    serialize: (value, state) => (isDefaultSort(state.sort, value) ? null : value),
+  },
+  page: {
+    param: PAGE_PARAM,
+    defaultValue: DEFAULT_PAGE,
+    parse: (raw) => (isValidPage(raw) ? Number(raw) : DEFAULT_PAGE),
+    serialize: (value) => (value === DEFAULT_PAGE ? null : String(value)),
+  },
+};
+
 // ── Component ──────────────────────────────────────────────────────────────
 
 export function StateCountyTable({ counties }: StateCountyTableProps) {
-  const router = useRouter();
-  const pathname = usePathname();
-  const searchParams = useSearchParams();
-
-  const rawSort = searchParams.get(SORT_PARAM);
-  const rawDir = searchParams.get(DIR_PARAM);
-  const rawPage = searchParams.get(PAGE_PARAM);
-
-  const sortField = isSortKey(rawSort) ? rawSort : DEFAULT_SORT_KEY;
-  const sortDir =
-    isSortKey(rawSort) && isSortDir(rawDir) ? rawDir : defaultDirForSort(sortField);
+  const { state: urlState, update: updateUrlState } = useUrlState(COUNTY_TABLE_URL_SPEC);
+  const sortField = urlState.sort;
+  const sortDir = urlState.dir;
 
   const sorted = [...counties].sort((a, b) => {
     let cmp = 0;
@@ -94,66 +117,23 @@ export function StateCountyTable({ counties }: StateCountyTableProps) {
   });
 
   const totalPages = Math.ceil(sorted.length / PAGE_SIZE);
-  const rawPageNum = isValidPage(rawPage) ? Number(rawPage) : DEFAULT_PAGE;
-  const page = totalPages > 0 ? Math.min(rawPageNum, totalPages - 1) : DEFAULT_PAGE;
+  const page = totalPages > 0 ? Math.min(urlState.page, totalPages - 1) : DEFAULT_PAGE;
 
-  // Canonicalise stale/invalid/default URL params
   useEffect(() => {
-    if (!rawSort && !rawDir && !rawPage) return;
-
-    const params = new URLSearchParams(searchParams.toString());
-
-    if (isDefaultSort(sortField, sortDir)) {
-      params.delete(SORT_PARAM);
-      params.delete(DIR_PARAM);
-    } else {
-      params.set(SORT_PARAM, sortField);
-      params.set(DIR_PARAM, sortDir);
+    if (urlState.page !== page) {
+      updateUrlState({ page });
     }
-
-    if (page === DEFAULT_PAGE) {
-      params.delete(PAGE_PARAM);
-    } else {
-      params.set(PAGE_PARAM, String(page));
-    }
-
-    if (params.toString() === searchParams.toString()) return;
-
-    const query = params.toString();
-    router.replace(query ? `${pathname}?${query}` : pathname, { scroll: false });
-  }, [page, pathname, rawDir, rawPage, rawSort, router, searchParams, sortDir, sortField]);
+  }, [page, updateUrlState, urlState.page]);
 
   function handleSort(field: SortField) {
     const nextDir =
       sortField === field ? (sortDir === "asc" ? "desc" : "asc") : defaultDirForSort(field);
-    const params = new URLSearchParams(searchParams.toString());
-
-    if (isDefaultSort(field, nextDir)) {
-      params.delete(SORT_PARAM);
-      params.delete(DIR_PARAM);
-    } else {
-      params.set(SORT_PARAM, field);
-      params.set(DIR_PARAM, nextDir);
-    }
-
-    params.delete(PAGE_PARAM);
-
-    const query = params.toString();
-    router.replace(query ? `${pathname}?${query}` : pathname, { scroll: false });
+    updateUrlState({ sort: field, dir: nextDir, page: DEFAULT_PAGE });
   }
 
   function handlePageChange(newPage: number) {
     const clamped = Math.max(DEFAULT_PAGE, Math.min(newPage, totalPages - 1));
-    const params = new URLSearchParams(searchParams.toString());
-
-    if (clamped === DEFAULT_PAGE) {
-      params.delete(PAGE_PARAM);
-    } else {
-      params.set(PAGE_PARAM, String(clamped));
-    }
-
-    const query = params.toString();
-    router.replace(query ? `${pathname}?${query}` : pathname, { scroll: false });
+    updateUrlState({ page: clamped });
   }
 
   const slice = sorted.slice(page * PAGE_SIZE, (page + 1) * PAGE_SIZE);

--- a/web/e2e/state.spec.ts
+++ b/web/e2e/state.spec.ts
@@ -54,6 +54,13 @@ test.describe("StateCountyTable URL-sync (/state/GA)", () => {
     await expect(page.locator('[data-testid="county-table"]')).toBeVisible();
   });
 
+  test("?page=bogus falls back to first page and rewrites URL", async ({ page }) => {
+    await gotoState(page, "?page=bogus");
+
+    await expect(page).toHaveURL(/\/state\/GA$/, { timeout: 5_000 });
+    await expect(page.locator('[data-testid="county-table"]')).toBeVisible();
+  });
+
   test("?page=999 clamps to last valid page and rewrites URL", async ({ page }) => {
     await gotoState(page, "?page=999");
 

--- a/web/lib/hooks/use-url-state.test.ts
+++ b/web/lib/hooks/use-url-state.test.ts
@@ -1,0 +1,126 @@
+import assert from "node:assert/strict";
+import type { UrlStateSpec } from "./use-url-state";
+
+type Sort = "date" | "race";
+type Dir = "asc" | "desc";
+
+interface TestState {
+  sort: Sort;
+  dir: Dir;
+}
+
+interface PageState {
+  page: number;
+}
+
+const defaultSort: Sort = "date";
+const defaultDir: Dir = "desc";
+
+function isSort(value: string | null): value is Sort {
+  return value === "date" || value === "race";
+}
+
+function isDir(value: string | null): value is Dir {
+  return value === "asc" || value === "desc";
+}
+
+function defaultDirForSort(sort: Sort): Dir {
+  return sort === "date" ? "desc" : "asc";
+}
+
+const spec: UrlStateSpec<TestState> = {
+  sort: {
+    param: "sort",
+    defaultValue: defaultSort,
+    parse: (raw) => (isSort(raw) ? raw : defaultSort),
+    serialize: (value, state) => (value === defaultSort && state.dir === defaultDir ? null : value),
+  },
+  dir: {
+    param: "dir",
+    defaultValue: defaultDir,
+    parse: (raw, params) => {
+      const sort = params.get("sort");
+      const sortValue = isSort(sort) ? sort : defaultSort;
+      return isSort(sort) && isDir(raw) ? raw : defaultDirForSort(sortValue);
+    },
+    serialize: (value, state) => (state.sort === defaultSort && value === defaultDir ? null : value),
+  },
+};
+
+const pageSpec: UrlStateSpec<PageState> = {
+  page: {
+    param: "page",
+    defaultValue: 0,
+    parse: (raw) => {
+      const page = Number(raw);
+      return Number.isInteger(page) && page >= 0 ? page : 0;
+    },
+    serialize: (value) => (value === 0 ? null : String(value)),
+  },
+};
+
+function parse(query: string): TestState {
+  const params = new URLSearchParams(query);
+  return {
+    sort: spec.sort.parse(params.get("sort"), params),
+    dir: spec.dir.parse(params.get("dir"), params),
+  };
+}
+
+function canonicalize(query: string, state = parse(query)): string {
+  const params = new URLSearchParams(query);
+  const serializedSort = spec.sort.serialize(state.sort, state);
+  if (serializedSort === null) {
+    params.delete(spec.sort.param);
+  } else {
+    params.set(spec.sort.param, serializedSort);
+  }
+
+  const serializedDir = spec.dir.serialize(state.dir, state);
+  if (serializedDir === null) {
+    params.delete(spec.dir.param);
+  } else {
+    params.set(spec.dir.param, serializedDir);
+  }
+  return params.toString();
+}
+
+function update(query: string, next: Partial<TestState>): string {
+  return canonicalize(query, { ...parse(query), ...next });
+}
+
+function parsePage(query: string): PageState {
+  const params = new URLSearchParams(query);
+  return {
+    page: pageSpec.page.parse(params.get("page"), params),
+  };
+}
+
+function canonicalizePage(query: string): string {
+  const params = new URLSearchParams(query);
+  const state = parsePage(query);
+  const serializedPage = pageSpec.page.serialize(state.page, state);
+  if (serializedPage === null) {
+    params.delete(pageSpec.page.param);
+  } else {
+    params.set(pageSpec.page.param, serializedPage);
+  }
+  return params.toString();
+}
+
+export function runUseUrlStateContractAssertions() {
+  assert.deepEqual(parse("sort=race&dir=asc"), { sort: "race", dir: "asc" });
+  assert.deepEqual(parse("sort=garbage&dir=asc"), { sort: "date", dir: "desc" });
+  assert.equal(canonicalize("sort=date&dir=desc"), "");
+  assert.equal(canonicalize("sort=garbage&dir=asc"), "");
+  assert.equal(update("", { sort: "race", dir: "asc" }), "sort=race&dir=asc");
+  assert.equal(update("page=2", { sort: "race", dir: "asc" }), "page=2&sort=race&dir=asc");
+  assert.equal(canonicalize("sort=race"), "sort=race&dir=asc");
+  assert.equal(canonicalize("sort=race&dir=asc"), "sort=race&dir=asc");
+  assert.equal(canonicalize("sort=race&dir=desc"), "sort=race&dir=desc");
+  assert.equal(canonicalize("sort=date&dir=asc"), "sort=date&dir=asc");
+  assert.equal(canonicalize("sort=race&dir=asc", { sort: "date", dir: "desc" }), "");
+  assert.equal(canonicalizePage("page=0"), "");
+  assert.equal(canonicalizePage("page=2"), "page=2");
+  assert.equal(canonicalizePage("page=bogus"), "");
+}

--- a/web/lib/hooks/use-url-state.ts
+++ b/web/lib/hooks/use-url-state.ts
@@ -1,0 +1,121 @@
+"use client";
+
+import { useCallback, useEffect, useMemo } from "react";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+
+export interface UrlFieldSpec<T, S = unknown> {
+  /** URL param name. */
+  param: string;
+  /** Value treated as "no param present in the URL". */
+  defaultValue: T;
+  /**
+   * Parse the raw param value, or null when absent, into T.
+   * Return defaultValue for invalid input so the hook can canonicalise it.
+   * The full query is provided for fields whose fallback depends on another
+   * URL value, such as PollsTable's dir default depending on sort.
+   */
+  parse: (raw: string | null, searchParams: URLSearchParams) => T;
+  /**
+   * Serialise T into URL form. Return null to omit the param.
+   * The full state is provided for fields whose omission depends on another
+   * field, such as preserving sort=date when dir=asc.
+   */
+  serialize: (value: T, state: S) => string | null;
+}
+
+export type UrlStateSpec<S> = { [K in keyof S]: UrlFieldSpec<S[K], S> };
+
+export interface UseUrlStateResult<S> {
+  state: S;
+  update: (next: Partial<S>) => void;
+  reset: () => void;
+}
+
+type SpecKey<S> = Extract<keyof S, string>;
+
+function specKeys<S extends object>(spec: UrlStateSpec<S>): SpecKey<S>[] {
+  return Object.keys(spec) as SpecKey<S>[];
+}
+
+function writeSpecValue<S extends object, K extends SpecKey<S>>(
+  params: URLSearchParams,
+  spec: UrlStateSpec<S>,
+  key: K,
+  state: S,
+) {
+  const field = spec[key];
+  const serializedValue = field.serialize(state[key], state);
+
+  if (serializedValue === null) {
+    params.delete(field.param);
+  } else {
+    params.set(field.param, serializedValue);
+  }
+}
+
+function buildUrl(pathname: string, params: URLSearchParams): string {
+  const query = params.toString();
+  return query ? `${pathname}?${query}` : pathname;
+}
+
+/**
+ * Derive object state from configured URL params and write updates back with
+ * canonical omit-at-default semantics.
+ *
+ * Keep the spec reference stable, usually by defining it outside the component.
+ * Example:
+ *
+ * const { state, update } = useUrlState(POLLS_URL_SPEC);
+ * update({ sort: "race", dir: "asc" });
+ */
+export function useUrlState<S extends object>(
+  spec: UrlStateSpec<S>,
+): UseUrlStateResult<S> {
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+
+  const state = useMemo(() => {
+    const next = {} as S;
+    for (const key of specKeys(spec)) {
+      next[key] = spec[key].parse(searchParams.get(spec[key].param), searchParams);
+    }
+    return next;
+  }, [searchParams, spec]);
+
+  const canonicalParams = useCallback(
+    (nextState: S) => {
+      const params = new URLSearchParams(searchParams.toString());
+      for (const key of specKeys(spec)) {
+        writeSpecValue(params, spec, key, nextState);
+      }
+      return params;
+    },
+    [searchParams, spec],
+  );
+
+  useEffect(() => {
+    const params = canonicalParams(state);
+    if (params.toString() === searchParams.toString()) return;
+    router.replace(buildUrl(pathname, params), { scroll: false });
+  }, [canonicalParams, pathname, router, searchParams, state]);
+
+  const update = useCallback(
+    (next: Partial<S>) => {
+      const merged = { ...state, ...next };
+      const params = canonicalParams(merged);
+      router.replace(buildUrl(pathname, params), { scroll: false });
+    },
+    [canonicalParams, pathname, router, state],
+  );
+
+  const reset = useCallback(() => {
+    const params = new URLSearchParams(searchParams.toString());
+    for (const key of specKeys(spec)) {
+      params.delete(spec[key].param);
+    }
+    router.replace(buildUrl(pathname, params), { scroll: false });
+  }, [pathname, router, searchParams, spec]);
+
+  return { state, update, reset };
+}


### PR DESCRIPTION
## Summary
- Migrates StateCountyTable URL parsing and writes to the shared useUrlState hook.
- Keeps data-dependent page clamping in StateCountyTable after totalPages is known.
- Adds focused URL-sync coverage for invalid page canonicalization and page-field hook contract behavior.

## References
- EPIC: /home/hayden/projects/agentic-box/knowledge/epics/wethervane-frontend-features-v29.md
- Decision: /home/hayden/projects/agentic-box/knowledge/decisions/2026-05-23-wethervane-v29.md

## Verification
- cd /home/hayden/projects/wethervane/web && npm run lint
- cd /home/hayden/projects/wethervane/web && npm run typecheck
- cd /home/hayden/projects/wethervane/web && npx playwright test e2e/state.spec.ts
- cd /home/hayden/projects/wethervane && .venv/bin/pytest --tb=no -q